### PR TITLE
Add CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+## Git conventions
+
+- Keep commits atomic. Don't introduce something broken or incorrect and fix it in a follow-up commit within the same PR.
+- Do not include coding session URLs in commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+See [AGENTS.md](AGENTS.md) for agent instructions.
+
+Follow the AGENTS.md standard as defined at <https://agents.md/>.


### PR DESCRIPTION
CLAUDE.md points to AGENTS.md and references the agents.md
standard (https://agents.md/).
