### PR TITLE
Fix CI pipeline ansible-lint failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,8 @@
 
 - Keep commits atomic. Don't introduce something broken or incorrect and fix it in a follow-up commit within the same PR.
 - Do not include coding session URLs in commit messages.
+
+## CI/CD
+
+- Pipeline failures are **critical** and must be resolved before any other work proceeds.
+- All tests must pass before a PR can be merged.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,16 @@
+===========================
+basalt.qemu Release Notes
+===========================
+
+.. contents:: Topics
+
+v0.1.0
+======
+
+Release Summary
+---------------
+Initial release of the ``basalt.qemu`` collection.
+
+Major Changes
+-------------
+- Added ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,6 +8,8 @@ authors:
 description: Ansible collection for managing QEMU/KVM hosts on Enterprise Linux
 license_file: LICENSE
 tags:
+  - infrastructure
+  - linux
   - qemu
   - kvm
   - virtualization


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.rst` to resolve `galaxy[no-changelog]` lint violation
- Add required Galaxy tags (`infrastructure`, `linux`) to resolve `galaxy[tags]` lint violation
- Update `AGENTS.md` with CI/CD policy: pipeline failures are critical, tests must pass before merge

Closes #8

## Test plan
- [ ] Verify ansible-lint passes in CI
- [ ] Confirm both lint and sanity jobs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)