### PR TITLE
Add branch-and-PR workflow rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 ## Git conventions
 
+- **Never commit directly to main/master.** Always create a feature branch and open a PR for changes.
 - Keep commits atomic. Don't introduce something broken or incorrect and fix it in a follow-up commit within the same PR.
 - Do not include coding session URLs in commit messages.
 


### PR DESCRIPTION
## Summary
- Adds rule to AGENTS.md enforcing that all changes go through feature branches and PRs, never committing directly to main/master.

## Test plan
- [x] Verify AGENTS.md contains the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)