### PR TITLE
Add PR-should-close-issue guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - **Never commit directly to main/master.** Always create a feature branch and open a PR for changes.
 - Keep commits atomic. Don't introduce something broken or incorrect and fix it in a follow-up commit within the same PR.
+- PRs should preferably close a GitHub issue. Create an issue first if one doesn't exist, and reference it in the PR body (e.g., `Closes #123`).
 - Do not include coding session URLs in commit messages.
 
 ## CI/CD


### PR DESCRIPTION
## Summary

- Add guideline that PRs should preferably reference and close a GitHub issue

## Test plan

- [ ] CI passes (lint, sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)