### PR TITLE
Add example playbooks and sample inventory

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,4 @@
 profile: production
 exclude_paths:
   - roles/*/molecule/
+  - playbooks/inventory.example.yml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,4 +24,5 @@ build_ignore:
   - AGENTS.md
   - molecule
   - tests
+  - playbooks
   - "roles/*/molecule"

--- a/playbooks/basic_qemu_host.yml
+++ b/playbooks/basic_qemu_host.yml
@@ -1,0 +1,9 @@
+---
+# Minimal playbook that sets up a QEMU/KVM host with default settings.
+# Usage:
+#   ansible-playbook -i inventory.yml basic_qemu_host.yml
+- name: Configure basic QEMU/KVM hosts
+  hosts: qemu_hosts
+  become: true
+  roles:
+    - basalt.qemu.qemu_host

--- a/playbooks/inventory.example.yml
+++ b/playbooks/inventory.example.yml
@@ -1,0 +1,13 @@
+---
+# Example inventory for the basalt.qemu collection.
+# Copy this file, adjust hostnames/IPs, and pass it to ansible-playbook
+# with -i inventory.yml.
+all:
+  children:
+    qemu_hosts:
+      hosts:
+        kvm1.example.com:
+        kvm2.example.com:
+    qemu_hosts_novnc:
+      hosts:
+        kvm-novnc1.example.com:

--- a/playbooks/novnc_qemu_host.yml
+++ b/playbooks/novnc_qemu_host.yml
@@ -1,0 +1,14 @@
+---
+# Playbook that sets up a QEMU/KVM host with noVNC enabled.
+# Usage:
+#   ansible-playbook -i inventory.yml novnc_qemu_host.yml
+- name: Configure QEMU/KVM hosts with noVNC
+  hosts: qemu_hosts_novnc
+  become: true
+  roles:
+    - role: basalt.qemu.qemu_host
+      vars:
+        qemu_host_novnc_enabled: true
+        # Customize noVNC settings as needed:
+        # qemu_host_novnc_listen_port: 6080
+        # qemu_host_novnc_version: "v1.5.0"


### PR DESCRIPTION
## Summary

- Add `playbooks/` directory with example playbooks and a sample inventory to help users get started with the collection
- `inventory.example.yml` — sample inventory with `qemu_hosts` and `qemu_hosts_novnc` groups
- `basic_qemu_host.yml` — minimal playbook applying `basalt.qemu.qemu_host` with defaults
- `novnc_qemu_host.yml` — playbook enabling noVNC with comments showing customizable settings

Closes #6

## Test plan

- [x] `ansible-lint` passes on the new playbook files (only pre-existing `galaxy[version-incorrect]` remains)
- [ ] CI lint and sanity checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)