### PR TITLE
Add create_vm role with qcow2 disk image creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,18 @@ jobs:
         working-directory: ansible_collections/basalt/qemu
 
   molecule:
-    name: Molecule (${{ matrix.scenario }})
+    name: Molecule - ${{ matrix.role }} (${{ matrix.scenario }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        scenario:
-          - default
-          - novnc
+        include:
+          - role: qemu_host
+            scenario: default
+          - role: qemu_host
+            scenario: novnc
+          - role: create_vm
+            scenario: default
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,4 +79,4 @@ jobs:
 
       - name: Run Molecule
         run: molecule test -s ${{ matrix.scenario }}
-        working-directory: roles/qemu_host
+        working-directory: roles/${{ matrix.role }}

--- a/roles/create_vm/defaults/main.yml
+++ b/roles/create_vm/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# List of VMs to create. Each entry is a dict with at least a `name` key.
+# Example:
+#   create_vm_vms:
+#     - name: myvm
+#       disk_size: 20G
+#       disk_format: qcow2
+create_vm_vms: []
+
+# Default disk size for VMs (used when a VM does not specify disk_size)
+create_vm_default_disk_size: "20G"
+
+# Default disk format
+create_vm_default_disk_format: qcow2
+
+# Directory for VM disk images (must match qemu_host_vm_image_dir)
+create_vm_image_dir: /var/lib/qemu/images
+
+# Owner/group for created images
+create_vm_service_user: qemu
+create_vm_service_group: qemu

--- a/roles/create_vm/meta/main.yml
+++ b/roles/create_vm/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Basalt
+  description: Create QEMU/KVM virtual machines
+  license: GPL-3.0-only
+  min_ansible_version: "2.15"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+  galaxy_tags:
+    - qemu
+    - kvm
+    - virtualization
+dependencies:
+  - role: qemu_host

--- a/roles/create_vm/molecule/default/converge.yml
+++ b/roles/create_vm/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: create_vm
+      create_vm_vms:
+        - name: testvm
+          disk_size: 1G

--- a/roles/create_vm/molecule/default/molecule.yml
+++ b/roles/create_vm/molecule/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: create-vm-default
+    image: geerlingguy/docker-rockylinux9-ansible:latest
+    command: ""
+    privileged: true
+    pre_build_image: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    tmpfs:
+      - /run
+      - /tmp
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/.."
+verifier:
+  name: ansible

--- a/roles/create_vm/molecule/default/verify.yml
+++ b/roles/create_vm/molecule/default/verify.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    # ── Disk image exists with correct properties ────────────
+    - name: Stat disk image
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm.qcow2
+      register: disk_image
+
+    - name: Assert disk image properties
+      ansible.builtin.assert:
+        that:
+          - disk_image.stat.exists
+          - disk_image.stat.pw_name == 'qemu'
+          - disk_image.stat.gr_name == 'qemu'
+          - disk_image.stat.mode == '0644'
+
+    - name: Check disk image is valid qcow2
+      ansible.builtin.command:
+        cmd: qemu-img info /var/lib/qemu/images/testvm.qcow2
+      register: qemu_img_info
+      changed_when: false
+
+    - name: Assert qcow2 format
+      ansible.builtin.assert:
+        that:
+          - "'file format: qcow2' in qemu_img_info.stdout"
+
+    # ── Idempotency ──────────────────────────────────────────
+    - name: Record image modification time
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm.qcow2
+      register: before_rerun
+
+    - name: Re-run create_vm role
+      ansible.builtin.include_role:
+        name: create_vm
+      vars:
+        create_vm_vms:
+          - name: testvm
+            disk_size: 1G
+
+    - name: Record image modification time after re-run
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm.qcow2
+      register: after_rerun
+
+    - name: Assert image was not recreated
+      ansible.builtin.assert:
+        that:
+          - before_rerun.stat.mtime == after_rerun.stat.mtime

--- a/roles/create_vm/tasks/disk.yml
+++ b/roles/create_vm/tasks/disk.yml
@@ -1,0 +1,21 @@
+---
+- name: Create qcow2 disk image for {{ item.name }}
+  ansible.builtin.command:
+    cmd: >-
+      qemu-img create -f {{ item.disk_format | default(create_vm_default_disk_format) }}
+      {{ create_vm_image_dir }}/{{ item.name }}.{{ item.disk_format | default(create_vm_default_disk_format) }}
+      {{ item.disk_size | default(create_vm_default_disk_size) }}
+    creates: "{{ create_vm_image_dir }}/{{ item.name }}.{{ item.disk_format | default(create_vm_default_disk_format) }}"
+  loop: "{{ create_vm_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Set ownership and permissions on disk images
+  ansible.builtin.file:
+    path: "{{ create_vm_image_dir }}/{{ item.name }}.{{ item.disk_format | default(create_vm_default_disk_format) }}"
+    owner: "{{ create_vm_service_user }}"
+    group: "{{ create_vm_service_group }}"
+    mode: "0644"
+  loop: "{{ create_vm_vms }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/create_vm/tasks/main.yml
+++ b/roles/create_vm/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Create VM disk images
+  ansible.builtin.import_tasks: disk.yml


### PR DESCRIPTION
## Summary

- Introduce `create_vm` role that creates qcow2 disk images for VMs, looping over `create_vm_vms` with idempotent `qemu-img create` (using `creates:` guard) and setting ownership/permissions
- Add Molecule tests verifying image properties, qcow2 validity, and idempotency
- Restructure CI molecule matrix to support multiple roles (`qemu_host` + `create_vm`)

Closes #19

## Test plan

- [ ] Molecule tests pass for `create_vm/default` scenario
- [ ] Existing `qemu_host` Molecule scenarios still pass
- [ ] ansible-lint and sanity checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)