### PR TITLE
Add argument_specs and README for roles

### DIFF
--- a/roles/create_vm/README.md
+++ b/roles/create_vm/README.md
@@ -1,0 +1,56 @@
+# basalt.qemu.create_vm
+
+Create QEMU/KVM virtual machine disk images on an Enterprise Linux host.
+
+The role creates qcow2 (or raw) disk images for each VM defined in `create_vm_vms`, sets the correct ownership and permissions, and is idempotent (existing images are not recreated).
+
+## Requirements
+
+- Ansible >= 2.15
+- Target hosts running Enterprise Linux 8 or 9
+
+## Dependencies
+
+- `basalt.qemu.qemu_host` — must be applied first to install QEMU and create the image directory.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `create_vm_vms` | `[]` | List of VMs to create (see below) |
+| `create_vm_default_disk_size` | `20G` | Default disk size when not specified per VM |
+| `create_vm_default_disk_format` | `qcow2` | Default disk format (`qcow2` or `raw`) |
+| `create_vm_image_dir` | `/var/lib/qemu/images` | Directory for disk images (should match `qemu_host_vm_image_dir`) |
+| `create_vm_service_user` | `qemu` | Owner of the created disk images |
+| `create_vm_service_group` | `qemu` | Group of the created disk images |
+
+### VM definition
+
+Each entry in `create_vm_vms` is a dictionary with the following keys:
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `name` | yes | — | VM name, used as the disk image filename |
+| `disk_size` | no | `create_vm_default_disk_size` | Disk image size (e.g. `20G`, `100G`) |
+| `disk_format` | no | `create_vm_default_disk_format` | Disk format (`qcow2` or `raw`) |
+
+## Example Playbook
+
+```yaml
+- hosts: hypervisors
+  roles:
+    - basalt.qemu.qemu_host
+    - role: basalt.qemu.create_vm
+      vars:
+        create_vm_vms:
+          - name: web01
+            disk_size: 40G
+          - name: db01
+            disk_size: 100G
+            disk_format: raw
+          - name: worker01
+```
+
+## License
+
+GPL-3.0-only

--- a/roles/create_vm/meta/argument_specs.yml
+++ b/roles/create_vm/meta/argument_specs.yml
@@ -1,0 +1,55 @@
+---
+argument_specs:
+  main:
+    short_description: Create QEMU/KVM virtual machine disk images.
+    description:
+      - Creates qcow2 (or raw) disk images for QEMU/KVM virtual machines
+        and sets the correct ownership and permissions.
+      - This role depends on C(basalt.qemu.qemu_host) to provide the host-level
+        QEMU installation and directory structure.
+    options:
+      create_vm_vms:
+        description:
+          - List of VMs to create. Each entry is a dictionary with at least a C(name) key.
+          - "Optional per-VM keys: C(disk_size) (overrides C(create_vm_default_disk_size)),
+            C(disk_format) (overrides C(create_vm_default_disk_format))."
+        type: list
+        elements: dict
+        default: []
+        options:
+          name:
+            description: Name of the VM. Used as the disk image filename.
+            type: str
+            required: true
+          disk_size:
+            description: Disk image size (e.g. C(20G), C(100G)). Overrides C(create_vm_default_disk_size).
+            type: str
+          disk_format:
+            description: Disk image format. Overrides C(create_vm_default_disk_format).
+            type: str
+            choices:
+              - qcow2
+              - raw
+      create_vm_default_disk_size:
+        description: Default disk size for VMs that do not specify C(disk_size).
+        type: str
+        default: "20G"
+      create_vm_default_disk_format:
+        description: Default disk image format.
+        type: str
+        default: qcow2
+        choices:
+          - qcow2
+          - raw
+      create_vm_image_dir:
+        description: Directory for VM disk images. Should match C(qemu_host_vm_image_dir).
+        type: path
+        default: /var/lib/qemu/images
+      create_vm_service_user:
+        description: Owner of the created disk image files.
+        type: str
+        default: qemu
+      create_vm_service_group:
+        description: Group of the created disk image files.
+        type: str
+        default: qemu

--- a/roles/qemu_host/meta/argument_specs.yml
+++ b/roles/qemu_host/meta/argument_specs.yml
@@ -1,0 +1,54 @@
+---
+argument_specs:
+  main:
+    short_description: Install and configure a QEMU/KVM host on Enterprise Linux.
+    description:
+      - Installs QEMU/KVM packages, deploys a systemd template unit for managing VMs,
+        and optionally sets up noVNC for browser-based console access.
+    options:
+      qemu_host_packages:
+        description: Packages to install for QEMU/KVM host.
+        type: list
+        elements: str
+        default:
+          - qemu-kvm
+          - qemu-img
+          - libvirt
+          - swtpm
+          - swtpm-tools
+      qemu_host_libvirtd_enabled:
+        description: Whether to enable and start libvirtd.
+        type: bool
+        default: true
+      qemu_host_vm_config_dir:
+        description: Directory containing QEMU VM configuration files (one C(.conf) per VM).
+        type: path
+        default: /etc/qemu/vms
+      qemu_host_vm_image_dir:
+        description: Directory containing QEMU VM disk images.
+        type: path
+        default: /var/lib/qemu/images
+      qemu_host_service_user:
+        description: User for the QEMU systemd service.
+        type: str
+        default: qemu
+      qemu_host_service_group:
+        description: Group for the QEMU systemd service.
+        type: str
+        default: qemu
+      qemu_host_novnc_enabled:
+        description: Whether to deploy noVNC for browser-based VNC console access.
+        type: bool
+        default: false
+      qemu_host_novnc_install_dir:
+        description: Directory where noVNC will be installed.
+        type: path
+        default: /opt/noVNC
+      qemu_host_novnc_version:
+        description: noVNC Git release tag to install.
+        type: str
+        default: "v1.5.0"
+      qemu_host_novnc_listen_port:
+        description: Port the noVNC websocket proxy listens on.
+        type: int
+        default: 6080


### PR DESCRIPTION
## Summary

- Add `meta/argument_specs.yml` to `qemu_host` role — documents all 10 variables with types, defaults, and descriptions
- Add `meta/argument_specs.yml` to `create_vm` role — documents all 6 variables including the nested `create_vm_vms` list structure
- Add `README.md` to `create_vm` role — follows the same format as the `qemu_host` README

Both argument_specs are validated by `ansible-doc -t role` and `ansible-lint`.

Closes #26
Closes #27
Closes #28

## Test plan

- [x] `ansible-lint` passes (only pre-existing `galaxy[version-incorrect]` warning)
- [x] `ansible-doc -t role -r roles qemu_host` renders correctly
- [x] `ansible-doc -t role -r roles create_vm` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)