### PR TITLE
Add README improvements, CONTRIBUTING.md, and docsite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to basalt.qemu
+
+Contributions are welcome! This document covers how to set up a development environment, run tests, and submit changes.
+
+## Prerequisites
+
+- Python >= 3.9
+- Ansible >= 2.15
+- Docker (for Molecule tests)
+- Git
+
+## Development Setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/maglo/ansible-collection-qemu.git
+cd ansible-collection-qemu
+```
+
+Install the required Python packages:
+
+```bash
+pip install ansible-core ansible-lint molecule molecule-plugins[docker]
+```
+
+## Running Tests
+
+### Lint
+
+```bash
+ansible-lint
+```
+
+### Sanity tests
+
+Sanity tests must run from within the expected collection path:
+
+```bash
+mkdir -p /tmp/collections/ansible_collections/basalt
+ln -s "$(pwd)" /tmp/collections/ansible_collections/basalt/qemu
+cd /tmp/collections/ansible_collections/basalt/qemu
+ansible-test sanity --color -v
+```
+
+### Molecule tests
+
+Run all scenarios for a role:
+
+```bash
+cd roles/qemu_host
+molecule test
+```
+
+Run a specific scenario:
+
+```bash
+cd roles/qemu_host
+molecule test -s novnc
+```
+
+## Git Workflow
+
+- **Never commit directly to `main`.** Always create a feature branch and open a PR.
+- PRs should close a GitHub issue. Create an issue first if one doesn't exist, and reference it in the PR body (e.g., `Closes #123`).
+- Keep commits atomic — don't introduce something broken and fix it in a follow-up commit within the same PR.
+
+## Adding a New Role
+
+1. Create the role directory under `roles/<role_name>/` with at minimum:
+   - `tasks/main.yml`
+   - `defaults/main.yml`
+   - `meta/main.yml` (with `galaxy_info` and `dependencies`)
+   - `meta/argument_specs.yml` (for `ansible-doc` support and runtime validation)
+   - `README.md`
+2. Add Molecule tests under `roles/<role_name>/molecule/default/`.
+3. Add the role to the CI matrix in `.github/workflows/ci.yml`.
+4. Add the role to the table in the root `README.md`.
+
+## Reporting Issues
+
+Open an issue on [GitHub](https://github.com/maglo/ansible-collection-qemu/issues) with a clear description and, if applicable, steps to reproduce.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 # Ansible Collection — basalt.qemu
 
+![CI](https://github.com/maglo/ansible-collection-qemu/actions/workflows/ci.yml/badge.svg)
+
 Ansible collection for managing QEMU/KVM hosts on Enterprise Linux (RHEL, Rocky, Alma, CentOS).
 
 ## Included Roles
 
 | Role | Description |
 |------|-------------|
-| `basalt.qemu.qemu_host` | Install QEMU/KVM packages, deploy a systemd template unit for VMs, and optionally set up noVNC |
+| [`basalt.qemu.qemu_host`](roles/qemu_host/README.md) | Install QEMU/KVM packages, deploy a systemd template unit for VMs, and optionally set up noVNC |
+| [`basalt.qemu.create_vm`](roles/create_vm/README.md) | Create QEMU/KVM virtual machine disk images |
 
-## Requirements
+## Supported Platforms
 
-- Ansible >= 2.15
-- Target hosts running Enterprise Linux 8 or 9
+| Platform | Versions |
+|----------|----------|
+| Enterprise Linux (RHEL, Rocky, Alma, CentOS) | 8, 9 |
+
+**Ansible compatibility:** >= 2.15
 
 ## Installation
 
@@ -34,6 +40,13 @@ collections:
     - role: basalt.qemu.qemu_host
       vars:
         qemu_host_novnc_enabled: true
+    - role: basalt.qemu.create_vm
+      vars:
+        create_vm_vms:
+          - name: web01
+            disk_size: 40G
+          - name: db01
+            disk_size: 100G
 ```
 
 After the role runs, manage individual VMs with the systemd template unit:
@@ -49,9 +62,11 @@ systemctl start qemu-vm@myvm
 systemctl enable qemu-vm@myvm
 ```
 
-## Role Variables
+See the [example playbooks](playbooks/) for more usage patterns.
 
-See [`roles/qemu_host/defaults/main.yml`](roles/qemu_host/defaults/main.yml) for the full list of configurable variables.
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and workflow guidelines.
 
 ## License
 

--- a/docs/docsite/config.yml
+++ b/docs/docsite/config.yml
@@ -1,0 +1,2 @@
+---
+flatmap: true

--- a/docs/docsite/extra-docs.yml
+++ b/docs/docsite/extra-docs.yml
@@ -1,0 +1,7 @@
+---
+sections:
+  - title: Guides
+    toctree:
+      - guide_qemu_host
+      - guide_vm_management
+      - guide_novnc

--- a/docs/docsite/rst/guide_qemu_host.rst
+++ b/docs/docsite/rst/guide_qemu_host.rst
@@ -1,0 +1,75 @@
+.. _basalt.qemu.guide_qemu_host:
+
+Getting started with qemu_host
+==============================
+
+This guide walks through setting up a QEMU/KVM hypervisor host using the ``basalt.qemu.qemu_host`` role.
+
+Prerequisites
+-------------
+
+- A target host running Enterprise Linux 8 or 9 (RHEL, Rocky, Alma, CentOS)
+- Ansible >= 2.15
+- The ``basalt.qemu`` collection installed
+
+Installation
+------------
+
+.. code-block:: bash
+
+   ansible-galaxy collection install basalt.qemu
+
+Basic setup
+-----------
+
+The simplest playbook installs QEMU/KVM packages, enables ``libvirtd``, and deploys a systemd template unit for managing VMs:
+
+.. code-block:: yaml
+
+   - hosts: hypervisors
+     roles:
+       - basalt.qemu.qemu_host
+
+This will:
+
+1. Install ``qemu-kvm``, ``qemu-img``, ``libvirt``, ``swtpm``, and ``swtpm-tools``.
+2. Enable and start ``libvirtd``.
+3. Create the VM configuration directory (``/etc/qemu/vms``).
+4. Create the VM image directory (``/var/lib/qemu/images``).
+5. Deploy the ``qemu-vm@.service`` systemd template unit.
+
+Customising packages
+--------------------
+
+Override ``qemu_host_packages`` to control which packages are installed:
+
+.. code-block:: yaml
+
+   - hosts: hypervisors
+     roles:
+       - role: basalt.qemu.qemu_host
+         vars:
+           qemu_host_packages:
+             - qemu-kvm
+             - qemu-img
+             - libvirt
+
+Customising directories
+-----------------------
+
+The VM configuration and image directories can be changed:
+
+.. code-block:: yaml
+
+   - hosts: hypervisors
+     roles:
+       - role: basalt.qemu.qemu_host
+         vars:
+           qemu_host_vm_config_dir: /opt/qemu/config
+           qemu_host_vm_image_dir: /opt/qemu/images
+
+Next steps
+----------
+
+- :ref:`basalt.qemu.guide_vm_management` — create and manage VMs
+- :ref:`basalt.qemu.guide_novnc` — enable browser-based VNC access

--- a/docs/docsite/rst/guide_vm_management.rst
+++ b/docs/docsite/rst/guide_vm_management.rst
@@ -1,0 +1,72 @@
+.. _basalt.qemu.guide_vm_management:
+
+VM management
+=============
+
+This guide covers creating and managing QEMU/KVM virtual machines with the ``basalt.qemu`` collection.
+
+Creating disk images
+--------------------
+
+Use the ``basalt.qemu.create_vm`` role to create disk images for your VMs:
+
+.. code-block:: yaml
+
+   - hosts: hypervisors
+     roles:
+       - basalt.qemu.qemu_host
+       - role: basalt.qemu.create_vm
+         vars:
+           create_vm_vms:
+             - name: web01
+               disk_size: 40G
+             - name: db01
+               disk_size: 100G
+               disk_format: raw
+             - name: worker01
+
+Each VM entry requires a ``name`` key. Optional keys:
+
+- ``disk_size`` — overrides ``create_vm_default_disk_size`` (default ``20G``)
+- ``disk_format`` — overrides ``create_vm_default_disk_format`` (default ``qcow2``)
+
+The role is idempotent — existing images are not recreated.
+
+Starting a VM
+-------------
+
+After the roles have run, each VM is controlled through the ``qemu-vm@.service`` systemd template unit.
+
+First, create a configuration file for the VM. The instance name (after ``@``) corresponds to the ``.conf`` filename without the extension:
+
+.. code-block:: bash
+
+   cat > /etc/qemu/vms/web01.conf <<'EOF'
+   QEMU_ARGS="-m 2048 -smp 2 -drive file=/var/lib/qemu/images/web01.qcow2,format=qcow2 -vnc :1"
+   EOF
+
+Then start and enable the VM:
+
+.. code-block:: bash
+
+   systemctl start qemu-vm@web01
+   systemctl enable qemu-vm@web01
+
+Managing VMs
+------------
+
+Standard ``systemctl`` commands apply:
+
+.. code-block:: bash
+
+   # Check status
+   systemctl status qemu-vm@web01
+
+   # Stop a VM (graceful, 120s timeout)
+   systemctl stop qemu-vm@web01
+
+   # Restart a VM
+   systemctl restart qemu-vm@web01
+
+   # Disable auto-start
+   systemctl disable qemu-vm@web01


### PR DESCRIPTION
## Summary

- **Improve root README** — add CI badge, role description table with links, supported platforms, Ansible compatibility, quick-start example, and contributing link
- **Add CONTRIBUTING.md** — prerequisites, dev setup, how to run lint/sanity/molecule tests, git workflow, and how to add a new role
- **Add docsite** — `docs/docsite/` with antsibull-docs config, extra-docs index, and two RST guides (getting started with qemu_host, VM management)

Closes #29
Closes #30
Closes #31

## Test plan

- [x] `ansible-lint` passes (only pre-existing `galaxy[version-incorrect]`)
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify docsite RST syntax is valid (manual or via `antsibull-docs lint-collection-docs` once argument_specs PR merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)