### PR TITLE
Add UEFI firmware (OVMF) support to create_vm role

### DIFF
--- a/roles/create_vm/defaults/main.yml
+++ b/roles/create_vm/defaults/main.yml
@@ -19,3 +19,12 @@ create_vm_image_dir: /var/lib/qemu/images
 # Owner/group for created images
 create_vm_service_user: qemu
 create_vm_service_group: qemu
+
+# Whether VMs default to UEFI boot (can be overridden per VM with `uefi` key)
+create_vm_default_uefi: true
+
+# Path to OVMF firmware code (read-only, shared across VMs)
+create_vm_ovmf_code: /usr/share/edk2/ovmf/OVMF_CODE.fd
+
+# Path to OVMF vars template (copied per-VM for writable NVRAM)
+create_vm_ovmf_vars_template: /usr/share/edk2/ovmf/OVMF_VARS.fd

--- a/roles/create_vm/molecule/default/converge.yml
+++ b/roles/create_vm/molecule/default/converge.yml
@@ -6,3 +6,4 @@
       create_vm_vms:
         - name: testvm
           disk_size: 1G
+          uefi: true

--- a/roles/create_vm/molecule/default/verify.yml
+++ b/roles/create_vm/molecule/default/verify.yml
@@ -28,11 +28,52 @@
         that:
           - "'file format: qcow2' in qemu_img_info.stdout"
 
+    # ── UEFI firmware ──────────────────────────────────────────
+    - name: Check edk2-ovmf is installed
+      ansible.builtin.dnf:
+        name: edk2-ovmf
+        state: present
+      register: ovmf_pkg
+      check_mode: true
+
+    - name: Assert edk2-ovmf is installed
+      ansible.builtin.assert:
+        that:
+          - not ovmf_pkg.changed
+
+    - name: Stat OVMF_CODE.fd
+      ansible.builtin.stat:
+        path: /usr/share/edk2/ovmf/OVMF_CODE.fd
+      register: ovmf_code
+
+    - name: Assert OVMF_CODE.fd exists
+      ansible.builtin.assert:
+        that:
+          - ovmf_code.stat.exists
+
+    - name: Stat per-VM NVRAM file
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm_VARS.fd
+      register: nvram_file
+
+    - name: Assert NVRAM file properties
+      ansible.builtin.assert:
+        that:
+          - nvram_file.stat.exists
+          - nvram_file.stat.pw_name == 'qemu'
+          - nvram_file.stat.gr_name == 'qemu'
+          - nvram_file.stat.mode == '0644'
+
     # ── Idempotency ──────────────────────────────────────────
     - name: Record image modification time
       ansible.builtin.stat:
         path: /var/lib/qemu/images/testvm.qcow2
       register: before_rerun
+
+    - name: Record NVRAM modification time
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm_VARS.fd
+      register: nvram_before_rerun
 
     - name: Re-run create_vm role
       ansible.builtin.include_role:
@@ -41,13 +82,24 @@
         create_vm_vms:
           - name: testvm
             disk_size: 1G
+            uefi: true
 
     - name: Record image modification time after re-run
       ansible.builtin.stat:
         path: /var/lib/qemu/images/testvm.qcow2
       register: after_rerun
 
+    - name: Record NVRAM modification time after re-run
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm_VARS.fd
+      register: nvram_after_rerun
+
     - name: Assert image was not recreated
       ansible.builtin.assert:
         that:
           - before_rerun.stat.mtime == after_rerun.stat.mtime
+
+    - name: Assert NVRAM was not overwritten
+      ansible.builtin.assert:
+        that:
+          - nvram_before_rerun.stat.mtime == nvram_after_rerun.stat.mtime

--- a/roles/create_vm/tasks/firmware.yml
+++ b/roles/create_vm/tasks/firmware.yml
@@ -1,0 +1,21 @@
+---
+- name: Install edk2-ovmf
+  ansible.builtin.dnf:
+    name: edk2-ovmf
+    state: present
+  when: create_vm_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list | length > 0
+        or (create_vm_vms | rejectattr('uefi', 'defined') | list | length > 0 and create_vm_default_uefi)
+
+- name: Copy OVMF_VARS per-VM
+  ansible.builtin.copy:
+    src: "{{ create_vm_ovmf_vars_template }}"
+    dest: "{{ create_vm_image_dir }}/{{ item.name }}_VARS.fd"
+    remote_src: true
+    force: false
+    owner: "{{ create_vm_service_user }}"
+    group: "{{ create_vm_service_group }}"
+    mode: "0644"
+  loop: "{{ create_vm_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list
+            + (create_vm_vms | rejectattr('uefi', 'defined') | list if create_vm_default_uefi else []) }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/create_vm/tasks/main.yml
+++ b/roles/create_vm/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
+- name: Ensure UEFI firmware is available
+  ansible.builtin.import_tasks: firmware.yml
+
 - name: Create VM disk images
   ansible.builtin.import_tasks: disk.yml


### PR DESCRIPTION
## Summary

Closes #20.

- Install `edk2-ovmf` package when any VM has UEFI enabled
- Copy OVMF_VARS template per-VM for writable NVRAM (`force: false` for idempotency)
- Add `create_vm_default_uefi`, `create_vm_ovmf_code`, and `create_vm_ovmf_vars_template` defaults
- Per-VM override via `uefi: true/false` key

## Test plan

- [ ] `molecule test` passes in `roles/create_vm`
- [ ] Verify `edk2-ovmf` package is installed
- [ ] Verify `OVMF_CODE.fd` exists at expected path
- [ ] Verify per-VM NVRAM file created with correct ownership and permissions
- [ ] Verify idempotency: NVRAM file not overwritten on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)