### PR TITLE
Fix create_vm argument validation and add CI gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,17 @@ jobs:
       - name: Run Molecule
         run: molecule test -s ${{ matrix.scenario }}
         working-directory: roles/${{ matrix.role }}
+
+  gate:
+    name: CI
+    if: always()
+    needs: [lint, sanity, docs, molecule]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required jobs
+        run: |-
+          results='${{ toJSON(needs.*.result) }}'
+          if echo "$results" | grep -qE '"(failure|cancelled)"'; then
+            echo "One or more required jobs did not succeed."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,16 @@
 
 - Pipeline failures are **critical** and must be resolved before any other work proceeds.
 - All tests must pass before a PR can be merged.
+- The `CI` gate job in `.github/workflows/ci.yml` **must pass** before merging any PR to `main`. This job aggregates all other CI jobs (lint, sanity, docs, molecule).
+
+## Branch protection
+
+- The `main` branch requires the **CI** status check to pass before merging.
+- Direct pushes to `main` are not allowed; all changes must go through a pull request.
+- Do not bypass or disable required status checks.
+
+## Roles
+
+- Every role variable used in tasks **must** be declared in `meta/argument_specs.yml` with correct type, description, and default.
+- Per-VM dictionary keys (e.g. inside `create_vm_vms` items) must also be declared in the `options` block of the list variable's argument spec.
+- Role `defaults/main.yml` and `meta/argument_specs.yml` must stay in sync — adding a default without a matching argument spec (or vice versa) will cause validation failures in CI.

--- a/roles/create_vm/README.md
+++ b/roles/create_vm/README.md
@@ -23,6 +23,9 @@ The role creates qcow2 (or raw) disk images for each VM defined in `create_vm_vm
 | `create_vm_image_dir` | `/var/lib/qemu/images` | Directory for disk images (should match `qemu_host_vm_image_dir`) |
 | `create_vm_service_user` | `qemu` | Owner of the created disk images |
 | `create_vm_service_group` | `qemu` | Group of the created disk images |
+| `create_vm_default_uefi` | `true` | Whether VMs default to UEFI boot when not specified per VM |
+| `create_vm_ovmf_code` | `/usr/share/edk2/ovmf/OVMF_CODE.fd` | Path to OVMF firmware code file |
+| `create_vm_ovmf_vars_template` | `/usr/share/edk2/ovmf/OVMF_VARS.fd` | Path to OVMF vars template (copied per VM) |
 
 ### VM definition
 
@@ -33,6 +36,7 @@ Each entry in `create_vm_vms` is a dictionary with the following keys:
 | `name` | yes | — | VM name, used as the disk image filename |
 | `disk_size` | no | `create_vm_default_disk_size` | Disk image size (e.g. `20G`, `100G`) |
 | `disk_format` | no | `create_vm_default_disk_format` | Disk format (`qcow2` or `raw`) |
+| `uefi` | no | `create_vm_default_uefi` | Whether to enable UEFI boot for this VM |
 
 ## Example Playbook
 
@@ -49,6 +53,7 @@ Each entry in `create_vm_vms` is a dictionary with the following keys:
             disk_size: 100G
             disk_format: raw
           - name: worker01
+            uefi: false
 ```
 
 ## License

--- a/roles/create_vm/meta/argument_specs.yml
+++ b/roles/create_vm/meta/argument_specs.yml
@@ -12,7 +12,8 @@ argument_specs:
         description:
           - List of VMs to create. Each entry is a dictionary with at least a C(name) key.
           - "Optional per-VM keys: C(disk_size) (overrides C(create_vm_default_disk_size)),
-            C(disk_format) (overrides C(create_vm_default_disk_format))."
+            C(disk_format) (overrides C(create_vm_default_disk_format)),
+            C(uefi) (overrides C(create_vm_default_uefi))."
         type: list
         elements: dict
         default: []
@@ -30,6 +31,9 @@ argument_specs:
             choices:
               - qcow2
               - raw
+          uefi:
+            description: Whether to enable UEFI boot for this VM. Overrides C(create_vm_default_uefi).
+            type: bool
       create_vm_default_disk_size:
         description: Default disk size for VMs that do not specify C(disk_size).
         type: str
@@ -53,3 +57,15 @@ argument_specs:
         description: Group of the created disk image files.
         type: str
         default: qemu
+      create_vm_default_uefi:
+        description: Whether VMs default to UEFI boot when not specified per-VM.
+        type: bool
+        default: true
+      create_vm_ovmf_code:
+        description: Path to the OVMF firmware code file (read-only, shared across VMs).
+        type: path
+        default: /usr/share/edk2/ovmf/OVMF_CODE.fd
+      create_vm_ovmf_vars_template:
+        description: Path to the OVMF vars template file (copied per-VM for writable NVRAM).
+        type: path
+        default: /usr/share/edk2/ovmf/OVMF_VARS.fd


### PR DESCRIPTION
The create_vm role's argument_specs.yml was missing the uefi per-VM
option and three UEFI-related top-level variables (create_vm_default_uefi,
create_vm_ovmf_code, create_vm_ovmf_vars_template) that were added in
the OVMF support PR. This caused Ansible's argument validation to reject
the undeclared uefi key during Molecule tests.

Also adds a CI gate job that aggregates all check results into a single
required status check, and documents branch protection and role variable
rules in AGENTS.md.