### PR TITLE
Add EL 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,12 @@ jobs:
         run: antsibull-docs lint-collection-docs --plugin-docs ansible_collections/basalt/qemu
 
   molecule:
-    name: Molecule - ${{ matrix.role }} (${{ matrix.scenario }})
+    name: Molecule - ${{ matrix.role }} (${{ matrix.scenario }}) - EL${{ matrix.el_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        el_version: [9, 10]
         include:
           - role: qemu_host
             scenario: default
@@ -121,6 +122,8 @@ jobs:
       - name: Run Molecule
         run: molecule test -s ${{ matrix.scenario }}
         working-directory: roles/${{ matrix.role }}
+        env:
+          EL_VERSION: ${{ matrix.el_version }}
 
   gate:
     name: CI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ansible collection for managing QEMU/KVM hosts on Enterprise Linux (RHEL, Rocky,
 
 | Platform | Versions |
 |----------|----------|
-| Enterprise Linux (RHEL, Rocky, Alma, CentOS) | 8, 9 |
+| Enterprise Linux (RHEL, Rocky, Alma, CentOS) | 9, 10 |
 
 **Ansible compatibility:** >= 2.15
 

--- a/roles/create_vm/README.md
+++ b/roles/create_vm/README.md
@@ -7,7 +7,7 @@ The role creates disk images, configures UEFI firmware, TPM emulation, and netwo
 ## Requirements
 
 - Ansible >= 2.15
-- Target hosts running Enterprise Linux 8 or 9
+- Target hosts running Enterprise Linux 9 or 10
 
 ## Dependencies
 

--- a/roles/create_vm/meta/main.yml
+++ b/roles/create_vm/meta/main.yml
@@ -7,8 +7,8 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - "8"
         - "9"
+        - "10"
   galaxy_tags:
     - qemu
     - kvm

--- a/roles/create_vm/molecule/default/molecule.yml
+++ b/roles/create_vm/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: create-vm-default
-    image: geerlingguy/docker-rockylinux9-ansible:latest
+    image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"
     command: ""
     privileged: true
     pre_build_image: true

--- a/roles/qemu_host/README.md
+++ b/roles/qemu_host/README.md
@@ -7,7 +7,7 @@ The role installs QEMU/KVM packages, deploys a systemd template unit for managin
 ## Requirements
 
 - Ansible >= 2.15
-- Target hosts running Enterprise Linux 8 or 9
+- Target hosts running Enterprise Linux 9 or 10
 
 ## Role Variables
 

--- a/roles/qemu_host/meta/main.yml
+++ b/roles/qemu_host/meta/main.yml
@@ -7,8 +7,8 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - "8"
         - "9"
+        - "10"
   galaxy_tags:
     - qemu
     - kvm

--- a/roles/qemu_host/molecule/default/molecule.yml
+++ b/roles/qemu_host/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: qemu-host-default
-    image: geerlingguy/docker-rockylinux9-ansible:latest
+    image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"
     command: ""
     privileged: true
     pre_build_image: true

--- a/roles/qemu_host/molecule/novnc/molecule.yml
+++ b/roles/qemu_host/molecule/novnc/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: qemu-host-novnc
-    image: geerlingguy/docker-rockylinux9-ansible:latest
+    image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"
     command: ""
     privileged: true
     pre_build_image: true


### PR DESCRIPTION
## Summary
- Updates supported platforms to EL 9 and EL 10, drops EL 8 support
- Updates role metadata in `meta/main.yml` for both `qemu_host` and `create_vm` roles
- Updates all README documentation to reflect new supported versions
- Adds EL version matrix to CI workflow to test against both EL 9 and EL 10

## Changes
- ✅ Updated `roles/qemu_host/meta/main.yml` - EL 9, 10
- ✅ Updated `roles/create_vm/meta/main.yml` - EL 9, 10
- ✅ Updated main `README.md` with supported versions
- ✅ Updated `roles/qemu_host/README.md` requirements
- ✅ Updated `roles/create_vm/README.md` requirements
- ✅ Enhanced CI workflow with EL version matrix (9, 10)
- ✅ Updated all molecule configurations for dynamic image selection

## Testing
The CI workflow now runs molecule tests against both:
- Rocky Linux 9 (`geerlingguy/docker-rockylinux9-ansible`)
- Rocky Linux 10 (`geerlingguy/docker-rockylinux10-ansible`)

## Notes
Since there has been no release yet, dropping EL 8 support is not a breaking change.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)