### PR TITLE
Add systemd dependency between qemu-vm and swtpm services for TPM-enabled VMs

### DIFF
--- a/roles/create_vm/tasks/tpm.yml
+++ b/roles/create_vm/tasks/tpm.yml
@@ -40,3 +40,31 @@
   loop: "{{ _create_vm_tpm_vms }}"
   loop_control:
     label: "{{ item.name }}"
+
+- name: Create systemd drop-in directory for qemu-vm@{{ item.name }}
+  ansible.builtin.file:
+    path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+  loop: "{{ _create_vm_tpm_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Deploy swtpm dependency override for TPM-enabled VMs
+  ansible.builtin.template:
+    src: qemu-vm-tpm-dependency.conf.j2
+    dest: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d/tpm-dependency.conf"
+    mode: '0644'
+    owner: root
+    group: root
+  loop: "{{ _create_vm_tpm_vms }}"
+  notify: Reload systemd
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when: _create_vm_tpm_vms | length > 0

--- a/roles/create_vm/templates/qemu-vm-tpm-dependency.conf.j2
+++ b/roles/create_vm/templates/qemu-vm-tpm-dependency.conf.j2
@@ -1,0 +1,5 @@
+# Managed by Ansible - create_vm role
+# TPM dependency for VM {{ item.name }}
+[Unit]
+After=swtpm@{{ item.name }}.service
+Requires=swtpm@{{ item.name }}.service


### PR DESCRIPTION
## Summary

Adds systemd drop-in configuration to enforce proper startup ordering and dependency between `qemu-vm@<vmname>.service` and `swtpm@<vmname>.service` for TPM-enabled VMs.

## Changes

- **New template**: `roles/create_vm/templates/qemu-vm-tpm-dependency.conf.j2`
  - Systemd drop-in that adds `After=` and `Requires=` directives

- **Updated**: `roles/create_vm/tasks/tpm.yml`
  - Creates drop-in directory `/etc/systemd/system/qemu-vm@<vmname>.service.d/`
  - Deploys `tpm-dependency.conf` for each TPM-enabled VM
  - Reloads systemd daemon after configuration

## Problem Solved

QEMU attempts to connect to the swtpm socket immediately on startup. Without explicit ordering, if `swtpm@<vmname>.service` hasn't started yet or the socket isn't ready, the VM fails to start with connection errors.

## Technical Approach

Uses systemd drop-in overrides to add conditional dependencies only for TPM-enabled VMs:
- `After=swtpm@<vmname>.service`: Ensures swtpm starts before qemu-vm
- `Requires=swtpm@<vmname>.service`: If swtpm fails, qemu-vm won't start

This approach keeps the shared `qemu-vm@.service` template generic while applying instance-specific configuration.

## Testing

Verify with a TPM-enabled VM:
```bash
# Check drop-in was created
ls -la /etc/systemd/system/qemu-vm@<vmname>.service.d/
cat /etc/systemd/system/qemu-vm@<vmname>.service.d/tpm-dependency.conf

# Verify dependencies
systemctl show qemu-vm@<vmname>.service -p After,Requires

# Test startup order
systemctl restart qemu-vm@<vmname>.service
journalctl -u swtpm@<vmname>.service -u qemu-vm@<vmname>.service --since "1 minute ago"
```

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)