### PR TITLE
Add USB disk image attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ansible collection for managing QEMU/KVM hosts on Enterprise Linux (RHEL, Rocky,
 | Role | Description |
 |------|-------------|
 | [`basalt.qemu.qemu_host`](roles/qemu_host/README.md) | Install QEMU/KVM packages, deploy a systemd template unit for VMs, and optionally set up noVNC |
-| [`basalt.qemu.create_vm`](roles/create_vm/README.md) | Create QEMU/KVM virtual machine disk images |
+| [`basalt.qemu.create_vm`](roles/create_vm/README.md) | Create QEMU/KVM virtual machine disk images and manage per-VM runtime options (UEFI/TPM/network/noVNC/USB image attach) |
 
 ## Supported Platforms
 
@@ -50,6 +50,10 @@ collections:
             disk_size: 100G
             disk_format: raw
             uefi: false
+          - name: installer
+            disk_size: 40G
+            usb_disk_image: /var/lib/qemu/images/installer.iso
+            usb_boot_priority: true
 ```
 
 `qemu_host` installs QEMU/KVM packages and deploys the `qemu-vm@.service` systemd

--- a/roles/create_vm/README.md
+++ b/roles/create_vm/README.md
@@ -11,7 +11,8 @@ The role creates disk images, configures UEFI firmware, TPM emulation, and netwo
 
 ## Dependencies
 
-- `basalt.qemu.qemu_host` — must be applied first to install QEMU and create the image directory.
+- No automatic role dependencies.
+- Prerequisite: apply `basalt.qemu.qemu_host` first (or provide equivalent host setup) so QEMU binaries, directories, and systemd templates exist.
 
 ## Role Variables
 
@@ -59,6 +60,8 @@ Each entry in `create_vm_vms` is a dictionary with the following keys:
 | `memory` | no | `create_vm_default_memory` | Memory allocation (e.g. `2G`, `4G`) |
 | `cpus` | no | `create_vm_default_cpus` | Number of virtual CPUs |
 | `vnc` | no | hash-based | VNC display number (port = 5900+N) |
+| `usb_disk_image` | no | — | Path to USB disk image to attach (`.iso`, `.raw`, `.img`, `.qcow2`) |
+| `usb_boot_priority` | no | `true` when `usb_disk_image` is set | Boot from USB first |
 | `novnc_enabled` | no | `create_vm_default_novnc_enabled` | Enable noVNC web console for this VM |
 | `novnc_port` | no | `6080 + vnc` | Port for noVNC web console (auto-assigned if not specified) |
 | `state` | no | `present` | Desired service state: `started`, `stopped`, `present`, `restarted`, or `absent` |
@@ -134,6 +137,30 @@ vncviewer <host>:<5900+display>
 ```
 
 **Security note:** VNC is unauthenticated by default. Consider firewall rules or VNC password authentication for production use.
+
+## USB Disk Image Attachment
+
+You can attach one pre-provisioned USB disk image per VM (for example installer or rescue media).
+When `usb_disk_image` is set, the role adds a USB 3.0 XHCI controller and USB storage device to QEMU.
+
+Supported image formats:
+- `.iso`
+- `.raw`
+- `.img`
+- `.qcow2`
+
+By default, USB is given boot priority when attached. You can disable this with `usb_boot_priority: false`.
+
+Example:
+
+```yaml
+create_vm_vms:
+  - name: installer-vm
+    disk_size: 40G
+    usb_disk_image: /var/lib/qemu/images/installer.iso
+    usb_boot_priority: true
+    state: started
+```
 
 ## noVNC Web Console
 

--- a/roles/create_vm/defaults/main.yml
+++ b/roles/create_vm/defaults/main.yml
@@ -5,6 +5,8 @@
 #     - name: myvm
 #       disk_size: 20G
 #       disk_format: qcow2
+#       usb_disk_image: /var/lib/qemu/images/installer.iso
+#       usb_boot_priority: true
 create_vm_vms: []
 
 # Default disk size for VMs (used when a VM does not specify disk_size)

--- a/roles/create_vm/meta/argument_specs.yml
+++ b/roles/create_vm/meta/argument_specs.yml
@@ -5,8 +5,8 @@ argument_specs:
     description:
       - Creates qcow2 (or raw) disk images for QEMU/KVM virtual machines
         and sets the correct ownership and permissions.
-      - This role depends on C(basalt.qemu.qemu_host) to provide the host-level
-        QEMU installation and directory structure.
+      - "Prerequisite: apply C(basalt.qemu.qemu_host) first (or provide equivalent host setup)
+        to ensure QEMU binaries and required directories already exist."
     options:
       create_vm_vms:
         description:
@@ -23,6 +23,8 @@ argument_specs:
             C(memory) (overrides C(create_vm_default_memory)),
             C(cpus) (overrides C(create_vm_default_cpus)),
             C(vnc) (VNC display number, auto-generated from VM name if not specified),
+            C(usb_disk_image) (path to USB disk image: iso/raw/img/qcow2),
+            C(usb_boot_priority) (boot from attached USB first; defaults to true when usb image is set),
             C(novnc_enabled) (enable noVNC web console for this VM),
             C(novnc_port) (noVNC port, auto-assigned if not specified),
             C(state) (C(started), C(stopped), or C(present))."
@@ -84,6 +86,16 @@ argument_specs:
               VNC display number for this VM (maps to port 5900+N).
               If not specified, calculated from hash of VM name.
             type: int
+          usb_disk_image:
+            description: >-
+              Path to a pre-provisioned USB disk image to attach to the VM.
+              Supported formats: C(.iso), C(.raw), C(.img), C(.qcow2).
+            type: path
+          usb_boot_priority:
+            description: >-
+              Whether to boot from attached USB storage first.
+              Defaults to C(true) when C(usb_disk_image) is set.
+            type: bool
           novnc_enabled:
             description: >-
               Enable noVNC web console for this VM. Overrides C(create_vm_default_novnc_enabled).

--- a/roles/create_vm/molecule/default/converge.yml
+++ b/roles/create_vm/molecule/default/converge.yml
@@ -1,6 +1,12 @@
 ---
 - name: Converge
   hosts: all
+  pre_tasks:
+    - name: Create test USB installer image
+      ansible.builtin.copy:
+        dest: /tmp/test-usb-installer.iso
+        content: "molecule-usb-test\n"
+        mode: "0644"
   roles:
     - role: create_vm
       create_vm_vms:
@@ -26,4 +32,13 @@
           uefi: false
           net_mode: user
           mac_address: "52:54:00:aa:bb:cc"
+          state: present
+        - name: testvm-usb
+          disk_size: 1G
+          usb_disk_image: /tmp/test-usb-installer.iso
+          state: present
+        - name: testvm-usb-noboot
+          disk_size: 1G
+          usb_disk_image: /tmp/test-usb-installer.iso
+          usb_boot_priority: false
           state: present

--- a/roles/create_vm/molecule/default/verify.yml
+++ b/roles/create_vm/molecule/default/verify.yml
@@ -192,6 +192,36 @@
           - "'-vnc :' in _content"
           - "'mac=52:54:00:aa:bb:cc' in _content"
 
+    # ── VM config — USB disk attachment ─────────────────────
+    - name: Read testvm-usb config
+      ansible.builtin.slurp:
+        src: /etc/qemu/vms/testvm-usb.conf
+      register: testvm_usb_conf
+
+    - name: Assert testvm-usb config has USB image and boot priority
+      vars:
+        _content: "{{ testvm_usb_conf.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'-device qemu-xhci,id=xhci' in _content"
+          - "'-drive if=none,id=usb0,format=raw,file=/tmp/test-usb-installer.iso' in _content"
+          - "'-device usb-storage,drive=usb0,bootindex=1' in _content"
+
+    - name: Read testvm-usb-noboot config
+      ansible.builtin.slurp:
+        src: /etc/qemu/vms/testvm-usb-noboot.conf
+      register: testvm_usb_noboot_conf
+
+    - name: Assert testvm-usb-noboot config disables USB boot priority
+      vars:
+        _content: "{{ testvm_usb_noboot_conf.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'-device qemu-xhci,id=xhci' in _content"
+          - "'-drive if=none,id=usb0,format=raw,file=/tmp/test-usb-installer.iso' in _content"
+          - "'-device usb-storage,drive=usb0' in _content"
+          - "'bootindex=1' not in _content"
+
     # ── bridge.conf ──────────────────────────────────────────
     - name: Stat bridge.conf
       ansible.builtin.stat:
@@ -264,6 +294,15 @@
             uefi: false
             net_mode: user
             mac_address: "52:54:00:aa:bb:cc"
+            state: present
+          - name: testvm-usb
+            disk_size: 1G
+            usb_disk_image: /tmp/test-usb-installer.iso
+            state: present
+          - name: testvm-usb-noboot
+            disk_size: 1G
+            usb_disk_image: /tmp/test-usb-installer.iso
+            usb_boot_priority: false
             state: present
 
     - name: Record image modification time after re-run

--- a/roles/create_vm/tasks/main.yml
+++ b/roles/create_vm/tasks/main.yml
@@ -34,5 +34,9 @@
   ansible.builtin.import_tasks: monitor.yml
   when: _create_vm_active_vms | length > 0
 
+- name: Validate USB disk image attachments
+  ansible.builtin.import_tasks: usb_disk.yml
+  when: _create_vm_active_vms | length > 0
+
 - name: Generate VM config and manage service
   ansible.builtin.import_tasks: service.yml

--- a/roles/create_vm/tasks/usb_disk.yml
+++ b/roles/create_vm/tasks/usb_disk.yml
@@ -1,0 +1,34 @@
+---
+- name: Determine VMs with USB disk image attachment
+  ansible.builtin.set_fact:
+    _create_vm_usb_vms: >-
+      {{ _create_vm_active_vms | selectattr('usb_disk_image', 'defined') | list }}
+
+- name: Validate USB disk image configuration
+  ansible.builtin.assert:
+    that:
+      - item.usb_disk_image | length > 0
+      - (item.usb_disk_image | lower | regex_search('\\.(iso|raw|img|qcow2)$')) is not none
+    fail_msg: >-
+      VM {{ item.name }}: usb_disk_image must end with .iso, .raw, .img, or .qcow2
+  loop: "{{ _create_vm_usb_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Check USB disk image exists
+  ansible.builtin.stat:
+    path: "{{ item.usb_disk_image }}"
+  register: _create_vm_usb_image_stats
+  loop: "{{ _create_vm_usb_vms }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.usb_disk_image }}"
+
+- name: Assert USB disk image file exists
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg
+    fail_msg: "VM {{ item.item.name }}: usb_disk_image '{{ item.item.usb_disk_image }}' does not exist"
+  loop: "{{ _create_vm_usb_image_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"

--- a/roles/create_vm/templates/vm.conf.j2
+++ b/roles/create_vm/templates/vm.conf.j2
@@ -16,6 +16,23 @@
 {% set _ = _args.append('-vnc :' ~ _vnc) %}
 {% set _ = _args.append('-monitor unix:/var/lib/qemu/' ~ item.name ~ '/monitor.sock,server,nowait') %}
 {% set _ = _args.append('-drive if=virtio,format=' ~ _fmt ~ ',file=' ~ create_vm_image_dir ~ '/' ~ item.name ~ '.' ~ _fmt) %}
+{% if item.usb_disk_image is defined and item.usb_disk_image %}
+{% set _usb_image = item.usb_disk_image %}
+{% set _usb_image_lower = _usb_image | lower %}
+{% if _usb_image_lower.endswith('.qcow2') %}
+{% set _usb_fmt = 'qcow2' %}
+{% else %}
+{% set _usb_fmt = 'raw' %}
+{% endif %}
+{% set _usb_boot_priority = item.usb_boot_priority | default(true) %}
+{% set _ = _args.append('-device qemu-xhci,id=xhci') %}
+{% set _ = _args.append('-drive if=none,id=usb0,format=' ~ _usb_fmt ~ ',file=' ~ _usb_image) %}
+{% if _usb_boot_priority %}
+{% set _ = _args.append('-device usb-storage,drive=usb0,bootindex=1') %}
+{% else %}
+{% set _ = _args.append('-device usb-storage,drive=usb0') %}
+{% endif %}
+{% endif %}
 {% if _uefi %}
 {% set _ = _args.append('-drive if=pflash,format=raw,readonly=on,file=' ~ create_vm_ovmf_code) %}
 {% set _ = _args.append('-drive if=pflash,format=raw,file=' ~ create_vm_image_dir ~ '/' ~ item.name ~ '_VARS.fd') %}


### PR DESCRIPTION
- Added USB disk image support to create_vm with per-VM usb_disk_image.
- Added per-VM usb_boot_priority to control USB-first boot behavior.
- Implemented validation for USB image path, existence, and supported formats (iso, raw, img, qcow2).
- Updated VM QEMU args generation to attach USB storage via XHCI.
- Updated argument specs, defaults comments, and role/root documentation.
- Extended [create_vm.yml](https://file+.vscode-resource.vscode-cdn.net/home/oscar/.vscode/extensions/openai.chatgpt-0.4.74-linux-x64/webview/#) example to include USB boot usage.
- Added Molecule default scenario coverage for USB attach and boot-priority cases.

Closes #47 