### PR TITLE
Add Podman support for Molecule driver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome! This document covers how to set up a development envi
 
 - Python >= 3.9
 - Ansible >= 2.15
-- Docker (for Molecule tests)
+- Docker or Podman (for Molecule tests)
 - Git
 
 ## Development Setup
@@ -21,7 +21,11 @@ cd ansible-collection-qemu
 Install the required Python packages:
 
 ```bash
-pip install ansible-core ansible-lint molecule molecule-plugins[docker]
+# Docker (default):
+pip install ansible-core ansible-lint molecule "molecule-plugins[docker]"
+
+# Podman (alternative):
+pip install ansible-core ansible-lint molecule "molecule-plugins[podman]"
 ```
 
 ## Running Tests
@@ -44,6 +48,12 @@ ansible-test sanity --color -v
 ```
 
 ### Molecule tests
+
+Molecule uses Docker by default. To use Podman instead, set `DRIVER` before running any `molecule` command:
+
+```bash
+export DRIVER=podman
+```
 
 Run all scenarios for a role:
 

--- a/roles/create_vm/molecule/default/molecule.yml
+++ b/roles/create_vm/molecule/default/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 platforms:
   - name: create-vm-default
     image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"

--- a/roles/create_vm/molecule/disk_image/molecule.yml
+++ b/roles/create_vm/molecule/disk_image/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 platforms:
   - name: create-vm-disk-image
     image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"

--- a/roles/create_vm/molecule/lifecycle/molecule.yml
+++ b/roles/create_vm/molecule/lifecycle/molecule.yml
@@ -5,7 +5,7 @@ dependency:
     requirements-file: ../../molecule_requirements.yml
 
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 
 platforms:
   - name: el9-lifecycle

--- a/roles/create_vm/molecule/novnc/molecule.yml
+++ b/roles/create_vm/molecule/novnc/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 platforms:
   - name: create-vm-novnc
     image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"

--- a/roles/qemu_host/molecule/default/molecule.yml
+++ b/roles/qemu_host/molecule/default/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 platforms:
   - name: qemu-host-default
     image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"

--- a/roles/qemu_host/molecule/novnc/molecule.yml
+++ b/roles/qemu_host/molecule/novnc/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: docker
+  name: ${DRIVER:-docker}
 platforms:
   - name: qemu-host-novnc
     image: "geerlingguy/docker-rockylinux${EL_VERSION:-9}-ansible:latest"


### PR DESCRIPTION
## Summary

- Replace hardcoded \`name: docker\` with \`name: \${MOLECULE_DRIVER:-docker}\` in all 6 \`molecule.yml\` files
- Update \`CONTRIBUTING.md\` to document Podman as an alternative and the \`MOLECULE_DRIVER\` env var
- CI is unchanged — no \`MOLECULE_DRIVER\` is set there, so it continues using Docker

Closes #60