### PR TITLE
Implement changelog fragments system (antsibull-changelog)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,4 @@ profile: production
 exclude_paths:
   - roles/*/molecule/
   - playbooks/inventory.example.yml
+  - changelogs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,28 @@ jobs:
         env:
           EL_VERSION: ${{ matrix.el_version }}
 
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install antsibull-changelog
+        run: pip install antsibull-changelog
+
+      - name: Lint changelog fragments
+        run: antsibull-changelog lint
+
   gate:
     name: CI
     if: always()
-    needs: [lint, sanity, docs, molecule]
+    needs: [lint, sanity, docs, molecule, changelog]
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,38 @@ An issue can have multiple labels (e.g. `documentation` + `ci` for a docs-lintin
 - Every role variable used in tasks **must** be declared in `meta/argument_specs.yml` with correct type, description, and default.
 - Per-VM dictionary keys (e.g. inside `create_vm_vms` items) must also be declared in the `options` block of the list variable's argument spec.
 - Role `defaults/main.yml` and `meta/argument_specs.yml` must stay in sync — adding a default without a matching argument spec (or vice versa) will cause validation failures in CI.
+
+## Changelog
+
+This project uses [antsibull-changelog](https://github.com/ansible-community/antsibull-changelog) to manage release notes via changelog fragments.
+
+**Every PR that introduces a user-visible change must include a changelog fragment.**
+
+- Place fragments in `changelogs/fragments/`.
+- Name files `<pr-number>-<short-slug>.yaml` (e.g. `42-fix-validation.yaml`). Use a descriptive slug without a PR number for changes that span multiple commits.
+- Fragment format:
+
+  ```yaml
+  ---
+  minor_changes:
+    - "role_name - Description of the change (closes #N)."
+  ```
+
+- Valid top-level keys:
+
+  | Key | When to use |
+  |-----|-------------|
+  | `major_changes` | Significant new functionality |
+  | `minor_changes` | Small new features, enhancements |
+  | `breaking_changes` | Backwards-incompatible changes |
+  | `bugfixes` | Bug fixes |
+  | `deprecated_features` | Features that will be removed |
+  | `removed_features` | Features removed in this release |
+  | `security_fixes` | Security-related fixes |
+  | `trivial` | CI, tooling, docs changes invisible to end users |
+  | `release_summary` | One-line release headline (at most one per release) |
+
+- A single fragment file may contain multiple keys.
+- Lint your fragment before opening a PR: `antsibull-changelog lint`
+- **Do not edit `CHANGELOG.rst` or `changelogs/changelog.yaml` directly.** Both files are managed by `antsibull-changelog`.
+- At release time the maintainer runs `antsibull-changelog release --version X.Y.Z` to compile all fragments into `CHANGELOG.rst` and update `changelogs/changelog.yaml`.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,81 +1,18 @@
-===========================
+=========================
 basalt.qemu Release Notes
-===========================
+=========================
 
 .. contents:: Topics
-
-Unreleased
-==========
-
-New Roles
----------
-- ``create_vm`` role for declarative VM creation with qcow2 disk support (PR #24).
-
-Breaking Changes
-----------------
-- **noVNC configuration refactored** (Issue #50): Per-VM noVNC configuration moved from ``qemu_host`` role to ``create_vm`` role for better separation of concerns.
-
-  - **Removed variables** from ``qemu_host`` role:
-
-    - ``qemu_host_novnc_vms`` (list of VMs)
-    - ``qemu_host_novnc_install_dir`` (installation directory)
-    - ``qemu_host_novnc_version`` (version tag)
-
-  - **New behavior**: ``qemu_host_novnc_enabled`` now only installs the ``novnc`` package from EPEL (no longer manages per-VM services).
-
-  - **Migration path**: Enable noVNC per-VM in the ``create_vm`` role using ``novnc_enabled: true`` on individual VM definitions.
-
-  - **Installation method changed**: noVNC is now installed via RPM package (``novnc`` from EPEL 9/10) instead of git clone to ``/opt/noVNC``.
-
-  - **Example migration**:
-
-    **Before** (qemu_host role)::
-
-        - role: basalt.qemu.qemu_host
-          vars:
-            qemu_host_novnc_enabled: true
-            qemu_host_novnc_vms:
-              - name: web01
-                novnc_port: 6080
-                vnc_target: localhost:5900
-
-    **After** (create_vm role)::
-
-        - role: basalt.qemu.qemu_host
-          vars:
-            qemu_host_novnc_enabled: true  # Install package only
-
-        - role: basalt.qemu.create_vm
-          vars:
-            create_vm_vms:
-              - name: web01
-                novnc_enabled: true
-                novnc_port: 6080  # Optional, auto-assigned if omitted
-
-  See ``roles/create_vm/README.md`` for full noVNC documentation.
-
-Minor Changes
--------------
-- create_vm — UEFI firmware (OVMF) boot support (PR #35).
-- create_vm — Per-VM noVNC web console configuration (Issue #50).
-- create_vm — Auto-port assignment for noVNC (defaults to ``6080 + VNC display number``).
-- qemu_host — Simplified noVNC handling: package installation only, per-VM config moved to ``create_vm`` (Issue #50).
-- qemu_host — Per-VM ``novnc@.service`` systemd template replacing shared service (PR #38).
-- Example playbooks and sample inventory (PR #13).
-- ``meta/argument_specs.yml`` and role-level READMEs (PR #33).
-- ``CONTRIBUTING.md`` and collection docsite (PR #34).
-
-Bugfixes
---------
-- create_vm — Fix argument validation for ``create_vm_vms`` items (PR #39).
 
 v0.1.0
 ======
 
 Release Summary
 ---------------
+
 Initial release of the ``basalt.qemu`` collection.
 
 Major Changes
 -------------
+
 - Added ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,10 @@
+---
+ancestor: null
+releases:
+  0.1.0:
+    changes:
+      release_summary: Initial release of the ``basalt.qemu`` collection.
+      major_changes:
+        - Added ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.
+    fragments: []
+    release_date: '2026-02-13'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,37 @@
+add_plugin_period: true
+changelog_nice_yaml: false
+changelog_sort: alphanumerical
+changes_file: changelog.yaml
+changes_format: combined
+ignore_other_fragment_extensions: true
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+output:
+- file: CHANGELOG.rst
+  format: rst
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: basalt.qemu
+trivial_section_name: trivial
+use_fqcn: true
+vcs: auto

--- a/changelogs/fragments/13-example-playbooks.yaml
+++ b/changelogs/fragments/13-example-playbooks.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Add example playbooks and sample inventory (PR #13)."

--- a/changelogs/fragments/24-create-vm-role.yaml
+++ b/changelogs/fragments/24-create-vm-role.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Added ``create_vm`` role for declarative VM creation with qcow2 disk support (PR #24)."

--- a/changelogs/fragments/33-argument-specs-readmes.yaml
+++ b/changelogs/fragments/33-argument-specs-readmes.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Add ``meta/argument_specs.yml`` and role-level READMEs for all roles (PR #33)."

--- a/changelogs/fragments/34-contributing-docsite.yaml
+++ b/changelogs/fragments/34-contributing-docsite.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Add ``CONTRIBUTING.md`` and collection docsite (PR #34)."

--- a/changelogs/fragments/35-uefi-support.yaml
+++ b/changelogs/fragments/35-uefi-support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add UEFI firmware (OVMF) boot support (PR #35)."

--- a/changelogs/fragments/38-novnc-service-template.yaml
+++ b/changelogs/fragments/38-novnc-service-template.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "qemu_host - Add per-VM ``novnc@.service`` systemd template, replacing the previous shared service (PR #38)."

--- a/changelogs/fragments/39-fix-argument-validation.yaml
+++ b/changelogs/fragments/39-fix-argument-validation.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "create_vm - Fix argument validation for ``create_vm_vms`` items (PR #39)."

--- a/changelogs/fragments/41-swtpm-tpm-support.yaml
+++ b/changelogs/fragments/41-swtpm-tpm-support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add per-VM ``swtpm`` service for TPM 2.0 emulation (PR #41)."

--- a/changelogs/fragments/43-vm-networking.yaml
+++ b/changelogs/fragments/43-vm-networking.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add VM networking configuration supporting bridge/tap and user-mode (NAT) networking (PR #43)."

--- a/changelogs/fragments/44-vm-config-service.yaml
+++ b/changelogs/fragments/44-vm-config-service.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Generate full VM configuration and manage ``qemu-vm@`` systemd service lifecycle (PR #44)."

--- a/changelogs/fragments/50-novnc-refactor.yaml
+++ b/changelogs/fragments/50-novnc-refactor.yaml
@@ -1,0 +1,15 @@
+---
+breaking_changes:
+  - >-
+    qemu_host - noVNC configuration refactored (issue #50). Per-VM noVNC
+    configuration moved from ``qemu_host`` role to ``create_vm`` role for better
+    separation of concerns. Removed variables: ``qemu_host_novnc_vms``,
+    ``qemu_host_novnc_install_dir``, ``qemu_host_novnc_version``.
+    ``qemu_host_novnc_enabled`` now only installs the ``novnc`` package from EPEL.
+    noVNC is installed via RPM package instead of git clone. Migrate by enabling
+    noVNC per-VM via ``novnc_enabled: true`` on individual VM definitions in the
+    ``create_vm`` role.
+minor_changes:
+  - "create_vm - Add per-VM noVNC web console configuration (issue #50)."
+  - "create_vm - Auto-assign noVNC port (defaults to ``6080 + VNC display number``) when not specified (issue #50)."
+  - "qemu_host - Simplify noVNC handling to package installation only; per-VM config moved to ``create_vm`` (issue #50)."

--- a/changelogs/fragments/53-el10-support.yaml
+++ b/changelogs/fragments/53-el10-support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Add Enterprise Linux 10 support; drop EL 8 (PR #53)."

--- a/changelogs/fragments/56-vm-lifecycle.yaml
+++ b/changelogs/fragments/56-vm-lifecycle.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add VM lifecycle management (start, stop, restart) support (PR #56)."

--- a/changelogs/fragments/59-usb-disk-image.yaml
+++ b/changelogs/fragments/59-usb-disk-image.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add USB disk image attachment support via ``usb_disk_image`` and ``usb_boot_priority`` parameters (closes #47, PR #59)."

--- a/changelogs/fragments/podman-molecule.yaml
+++ b/changelogs/fragments/podman-molecule.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Add Podman support as an alternative Molecule driver."

--- a/changelogs/fragments/swtpm-refactor.yaml
+++ b/changelogs/fragments/swtpm-refactor.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "qemu_host - Refactor ``swtpm@.service`` template deployment to ``qemu_host`` role."
+  - "create_vm - Add systemd dependency between ``qemu-vm@`` and ``swtpm@`` services for TPM-enabled VMs."

--- a/changelogs/fragments/url-disk-image.yaml
+++ b/changelogs/fragments/url-disk-image.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "create_vm - Add URL-based disk image provisioning with backing file support."


### PR DESCRIPTION
## Summary

- Initializes `antsibull-changelog` with `changelogs/config.yaml` and `changelogs/changelog.yaml` (seeded with v0.1.0 release history)
- Adds 17 changelog fragments covering all unreleased changes since v0.1.0, including the required backfill for PR #59 (USB disk image attachment support)
- Regenerates `CHANGELOG.rst` from the structured data; the manually-maintained Unreleased section is replaced by the fragment files
- Adds a `changelog` CI job running `antsibull-changelog lint` on every PR, enforced via the gate job
- Documents the fragment workflow in `AGENTS.md` so all contributors add a fragment with every user-visible change

### Fragment backfill

Fragments were created for all unreleased PRs/commits not previously captured:
- #13 (example playbooks), #24 (create_vm role), #33 (argument_specs), #34 (CONTRIBUTING.md)
- #35 (UEFI), #38 (novnc@.service), #39 (validation bugfix), #41 (swtpm)
- #43 (VM networking), #44 (VM config/service), #50 (noVNC refactor, breaking)
- #53 (EL10 support), #56 (VM lifecycle), swtpm refactor, URL disk provisioning
- **#59 (USB disk image) — required backfill per issue comment**
- Podman Molecule driver (trivial)

### Release workflow going forward

```
# Maintainer runs at release time:
antsibull-changelog release --version X.Y.Z
```

This compiles all pending fragments into `CHANGELOG.rst` and `changelogs/changelog.yaml`.

## Test plan

- [ ] CI `changelog` job passes (`antsibull-changelog lint` exits 0)
- [ ] All other CI jobs (lint, sanity, docs, molecule) unaffected
- [ ] Gate job passes

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)