### PR TITLE
Add release tooling and fix pre-release changelog state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ansible-core
+        run: pip install ansible-core
+
+      - name: Build collection tarball
+        run: ansible-galaxy collection build --force
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: basalt-qemu-*.tar.gz
+          generate_release_notes: false
+          body: |
+            See [CHANGELOG.rst](https://github.com/maglo/ansible-collection-qemu/blob/${{ github.ref_name }}/CHANGELOG.rst) for release notes.
+
+      # Uncomment to publish to Ansible Galaxy.
+      # Requires GALAXY_API_KEY to be set as a repository secret.
+      # - name: Publish to Ansible Galaxy
+      #   run: ansible-galaxy collection publish basalt-qemu-*.tar.gz \
+      #     --api-key "${{ secrets.GALAXY_API_KEY }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,43 @@ An issue can have multiple labels (e.g. `documentation` + `ci` for a docs-lintin
 - Per-VM dictionary keys (e.g. inside `create_vm_vms` items) must also be declared in the `options` block of the list variable's argument spec.
 - Role `defaults/main.yml` and `meta/argument_specs.yml` must stay in sync — adding a default without a matching argument spec (or vice versa) will cause validation failures in CI.
 
+## Releases
+
+### Release checklist
+
+1. Ensure all planned changes are merged to `main` and CI is green.
+2. Run `make release VERSION=x.y.z`. This will:
+   - Compile all changelog fragments into `CHANGELOG.rst` via `antsibull-changelog`.
+   - Bump `version` in `galaxy.yml`.
+   - Build the collection tarball.
+3. Review the diff (`git diff`) and commit:
+   ```
+   git add CHANGELOG.rst changelogs/changelog.yaml galaxy.yml
+   git commit -m "Release vX.Y.Z"
+   ```
+4. Open a PR for the release commit. Merge it.
+5. Tag the release from `main`:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+6. The `.github/workflows/release.yml` workflow fires automatically, creates a GitHub
+   Release, and attaches the tarball.
+
+To publish to Ansible Galaxy: set `GALAXY_API_KEY` in the environment and uncomment the
+`publish` target in `Makefile` (and the corresponding step in `release.yml`).
+
+### Makefile targets
+
+| Target    | Description                                                         |
+|-----------|---------------------------------------------------------------------|
+| `build`   | Build the collection tarball with `ansible-galaxy`                  |
+| `clean`   | Remove built tarballs (`basalt-qemu-*.tar.gz`)                      |
+| `release` | Compile changelog, bump version, build. Usage: `make release VERSION=x.y.z` |
+| `publish` | (Commented out) Publish to Galaxy with `GALAXY_API_KEY`             |
+
+Run `make help` for a quick reference.
+
 ## Changelog
 
 This project uses [antsibull-changelog](https://github.com/ansible-community/antsibull-changelog) to manage release notes via changelog fragments.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,11 @@
-=========================
+===========================
 basalt.qemu Release Notes
-=========================
+===========================
 
 .. contents:: Topics
 
-v0.1.0
-======
+Upcoming
+========
 
 Release Summary
 ---------------
@@ -15,4 +15,45 @@ Initial release of the ``basalt.qemu`` collection.
 Major Changes
 -------------
 
-- Added ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.
+- qemu_host - Add ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.
+- qemu_host - noVNC configuration refactored (issue #50). Per-VM noVNC configuration
+  moved from ``qemu_host`` role to ``create_vm`` role for better separation of concerns.
+  Removed variables: ``qemu_host_novnc_vms``, ``qemu_host_novnc_install_dir``,
+  ``qemu_host_novnc_version``. ``qemu_host_novnc_enabled`` now only installs the
+  ``novnc`` package from EPEL. noVNC is installed via RPM package instead of git clone.
+  Migrate by enabling noVNC per-VM via ``novnc_enabled: true`` on individual VM
+  definitions in the ``create_vm`` role.
+
+Minor Changes
+-------------
+
+- Add ``CONTRIBUTING.md`` and collection docsite (PR #34).
+- Add ``meta/argument_specs.yml`` and role-level READMEs for all roles (PR #33).
+- Add Enterprise Linux 10 support; drop EL 8 (PR #53).
+- Add example playbooks and sample inventory (PR #13).
+- Added ``create_vm`` role for declarative VM creation with qcow2 disk support (PR #24).
+- create_vm - Add UEFI firmware (OVMF) boot support (PR #35).
+- create_vm - Add USB disk image attachment support via ``usb_disk_image`` and
+  ``usb_boot_priority`` parameters (closes #47, PR #59).
+- create_vm - Add URL-based disk image provisioning with backing file support.
+- create_vm - Add VM lifecycle management (start, stop, restart) support (PR #56).
+- create_vm - Add VM networking configuration supporting bridge/tap and user-mode (NAT)
+  networking (PR #43).
+- create_vm - Add per-VM ``swtpm`` service for TPM 2.0 emulation (PR #41).
+- create_vm - Add per-VM noVNC web console configuration (issue #50).
+- create_vm - Add systemd dependency between ``qemu-vm@`` and ``swtpm@`` services for
+  TPM-enabled VMs.
+- create_vm - Auto-assign noVNC port (defaults to ``6080 + VNC display number``) when
+  not specified (issue #50).
+- create_vm - Generate full VM configuration and manage ``qemu-vm@`` systemd service
+  lifecycle (PR #44).
+- qemu_host - Add per-VM ``novnc@.service`` systemd template, replacing the previous
+  shared service (PR #38).
+- qemu_host - Refactor ``swtpm@.service`` template deployment to ``qemu_host`` role.
+- qemu_host - Simplify noVNC handling to package installation only; per-VM config moved
+  to ``create_vm`` (issue #50).
+
+Bugfixes
+--------
+
+- create_vm - Fix argument validation for ``create_vm_vms`` items (PR #39).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,37 @@ molecule test -s novnc
 3. Add the role to the CI matrix in `.github/workflows/ci.yml`.
 4. Add the role to the table in the root `README.md`.
 
+## Releasing
+
+Only maintainers with push access to the repository can cut releases.
+
+1. Ensure all planned changes are merged to `main` and CI is green.
+2. Run `make release VERSION=x.y.z`. This compiles changelog fragments, bumps the
+   version in `galaxy.yml`, and builds the collection tarball.
+3. Review the diff and commit:
+   ```bash
+   git diff
+   git add CHANGELOG.rst changelogs/changelog.yaml galaxy.yml
+   git commit -m "Release vX.Y.Z"
+   ```
+4. Open a PR for the release commit. Merge it.
+5. Tag and push from `main`:
+   ```bash
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+   The `release` GitHub Actions workflow fires automatically and creates a GitHub Release
+   with the tarball attached.
+
+### Makefile
+
+```bash
+make build                   # build the collection tarball
+make clean                   # remove built tarballs
+make release VERSION=x.y.z  # compile changelog, bump version, build
+make help                    # list all targets
+```
+
 ## Reporting Issues
 
 Open an issue on [GitHub](https://github.com/maglo/ansible-collection-qemu/issues) with a clear description and, if applicable, steps to reproduce.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+VERSION  := $(shell grep '^version:' galaxy.yml | awk '{print $$2}')
+TARBALL  := basalt-qemu-$(VERSION).tar.gz
+
+.PHONY: build clean release help
+
+build: ## Build the collection tarball
+	ansible-galaxy collection build --force
+
+clean: ## Remove built tarballs
+	rm -f basalt-qemu-*.tar.gz
+
+# Usage: make release VERSION=x.y.z
+release: ## Compile changelog and prepare a release. Usage: make release VERSION=x.y.z
+	@test -n "$(VERSION)" || { echo "Usage: make release VERSION=x.y.z"; exit 1; }
+	antsibull-changelog release --version $(VERSION)
+	sed -i.bak "s/^version:.*/version: $(VERSION)/" galaxy.yml && rm -f galaxy.yml.bak
+	ansible-galaxy collection build --force
+	@echo ""
+	@echo "Release $(VERSION) prepared. Next steps:"
+	@echo "  1. Review: git diff"
+	@echo "  2. Commit: git add CHANGELOG.rst changelogs/changelog.yaml galaxy.yml"
+	@echo "             git commit -m 'Release v$(VERSION)'"
+	@echo "  3. Open PR, get it merged to main, then tag:"
+	@echo "       git tag -a v$(VERSION) -m 'Release v$(VERSION)'"
+	@echo "       git push origin v$(VERSION)"
+	@echo "     The GitHub Actions release workflow will create a GitHub Release"
+	@echo "     and attach $(TARBALL) automatically."
+
+# Uncomment to publish to Ansible Galaxy.
+# Requires GALAXY_API_KEY to be set in the environment.
+# publish: build ## Publish to Ansible Galaxy (requires GALAXY_API_KEY)
+# 	ansible-galaxy collection publish $(TARBALL) --api-key $(GALAXY_API_KEY)
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  %-10s %s\n", $$1, $$2}'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,10 +1,3 @@
 ---
 ancestor: null
-releases:
-  0.1.0:
-    changes:
-      release_summary: Initial release of the ``basalt.qemu`` collection.
-      major_changes:
-        - Added ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux.
-    fragments: []
-    release_date: '2026-02-13'
+releases: {}

--- a/changelogs/fragments/00-initial-release.yaml
+++ b/changelogs/fragments/00-initial-release.yaml
@@ -1,0 +1,4 @@
+---
+release_summary: "Initial release of the ``basalt.qemu`` collection."
+major_changes:
+  - "qemu_host - Add ``qemu_host`` role for managing QEMU/KVM hosts on Enterprise Linux."

--- a/changelogs/fragments/50-novnc-refactor.yaml
+++ b/changelogs/fragments/50-novnc-refactor.yaml
@@ -1,5 +1,5 @@
 ---
-breaking_changes:
+major_changes:
   - >-
     qemu_host - noVNC configuration refactored (issue #50). Per-VM noVNC
     configuration moved from ``qemu_host`` role to ``create_vm`` role for better

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,6 +22,7 @@ build_ignore:
   - .ansible-lint
   - CLAUDE.md
   - AGENTS.md
+  - Makefile
   - molecule
   - tests
   - playbooks


### PR DESCRIPTION
## Summary

- **Makefile** with `build`, `clean`, `release VERSION=x.y.z`, and `help` targets; `publish` target is commented out (no Galaxy API token yet)
- **`.github/workflows/release.yml`** triggered on `v*` tags: builds tarball, creates GitHub Release; Galaxy publish step is commented out
- **Changelog state cleanup**: `changelogs/changelog.yaml` had a fake `0.1.0` placeholder release (no release has actually been made); removed it and moved the content to a proper fragment (`00-initial-release.yaml`)
- **`50-novnc-refactor.yaml`**: changed `breaking_changes` → `major_changes` (no prior release = no users to break)
- **`CHANGELOG.rst`**: one-time manual rebuild showing an `Upcoming` section with all 18 fragments compiled; removes incorrect `v0.1.0` stub. At real release time `antsibull-changelog release --version x.y.z` takes over.
- **`galaxy.yml`**: `Makefile` added to `build_ignore` so it isn't bundled in the Galaxy tarball
- **`AGENTS.md`** + **`CONTRIBUTING.md`**: release process documented

## Test plan

- [ ] `antsibull-changelog lint` passes (CI changelog job)
- [ ] `make build` produces `basalt-qemu-0.1.0.tar.gz`
- [ ] `make help` prints the targets table
- [ ] `make clean` removes the tarball
- [ ] All CI jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)