### PR TITLE
Fix Galaxy publish: use --token instead of --api-key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Publish to Ansible Galaxy
         run: ansible-galaxy collection publish maglo-qemu-*.tar.gz \
-          --api-key "${{ secrets.GALAXY_API_KEY }}"
+          --token "${{ secrets.GALAXY_API_KEY }}"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release: ## Compile changelog and prepare a release. Usage: make release VERSION
 	@echo "     and attach $(TARBALL) automatically."
 
 publish: build ## Publish to Ansible Galaxy (requires GALAXY_API_KEY)
-	ansible-galaxy collection publish $(TARBALL) --api-key $(GALAXY_API_KEY)
+	ansible-galaxy collection publish $(TARBALL) --token $(GALAXY_API_KEY)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
## Summary

- Replaces `--api-key` with `--token` in `.github/workflows/release.yml`
- Replaces `--api-key` with `--token` in `Makefile`

Recent versions of `ansible-core` removed `--api-key` from `ansible-galaxy collection publish` in favour of `--token`. This caused the v0.1.0 release workflow to fail on the publish step (GitHub Release was created successfully, only Galaxy publish failed).

Closes #71