### PR TITLE
Fix Galaxy publish: move path argument after options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,4 @@ jobs:
             See [CHANGELOG.rst](https://github.com/maglo/ansible-collection-qemu/blob/${{ github.ref_name }}/CHANGELOG.rst) for release notes.
 
       - name: Publish to Ansible Galaxy
-        run: ansible-galaxy collection publish maglo-qemu-*.tar.gz \
-          --token "${{ secrets.GALAXY_API_KEY }}"
+        run: ansible-galaxy collection publish --token "${{ secrets.GALAXY_API_KEY }}" maglo-qemu-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ release: ## Compile changelog and prepare a release. Usage: make release VERSION
 	@echo "     and attach $(TARBALL) automatically."
 
 publish: build ## Publish to Ansible Galaxy (requires GALAXY_API_KEY)
-	ansible-galaxy collection publish $(TARBALL) --token $(GALAXY_API_KEY)
+	ansible-galaxy collection publish --token $(GALAXY_API_KEY) $(TARBALL)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \


### PR DESCRIPTION
## Summary

- Moves the tarball path after `--token` in both `release.yml` and `Makefile`
- Removes the backslash line-continuation to avoid YAML-folding producing a stray `\ ` argument

`ansible-galaxy collection publish` expects optional arguments before the positional `path` argument.

Closes #71