### PR TITLE
Fix 10 bugs from v0.1.0 manual testing; release v0.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,28 @@ maglo.qemu Release Notes
 
 .. contents:: Topics
 
+v0.1.1
+======
+
+Release Summary
+---------------
+
+Bug-fix release addressing 10 issues found during manual testing of v0.1.0 on AlmaLinux 8 and EL9 with SELinux enforcing. See `#84 <https://github.com/maglo/ansible-collection-qemu/issues/84>`_ for the full test report.
+
+Bugfixes
+--------
+
+- host role - Add ``become: true`` to all privileged tasks (package installation, directory creation, systemd service management) so the role can be used without ``become: true`` at playbook level (`#74 <https://github.com/maglo/ansible-collection-qemu/issues/74>`_).
+- host role - Change ``host_libvirtd_enabled`` default from ``true`` to ``false`` to honour the Libvirt-free design principle and prevent libvirtd from blocking plays when it fails to start (`#75 <https://github.com/maglo/ansible-collection-qemu/issues/75>`_).
+- host role - Rename task ``"Enable and start libvirtd"`` to ``"Manage state of libvirtd service"`` to accurately reflect its conditional behaviour (`#76 <https://github.com/maglo/ansible-collection-qemu/issues/76>`_).
+- host role - Remove dead ``"Remove legacy single-instance noVNC service"`` task; v0.1.0 is the first release and has no legacy service to clean up (`#77 <https://github.com/maglo/ansible-collection-qemu/issues/77>`_).
+- vms role - Make OVMF firmware paths configurable with per-OS defaults using ``ansible_distribution_major_version``; fixes hardcoded path that does not exist on EL8 (`#78 <https://github.com/maglo/ansible-collection-qemu/issues/78>`_).
+- vms role - Add ``"Verify VM service is running"`` task after starting ``qemu-vm@<name>.service``; the play now fails with a clear error if the service does not reach active state (`#79 <https://github.com/maglo/ansible-collection-qemu/issues/79>`_).
+- docs - Add EPEL to the Prerequisites section of ``README.md`` and ``roles/host/README.md``; note that the collection intentionally does not manage EPEL to support airgapped deployments (`#80 <https://github.com/maglo/ansible-collection-qemu/issues/80>`_).
+- vms role - Ship a minimal SELinux policy module (``qemu_vm.te``) and tasks to compile and install it on EL9/EL10 hosts with SELinux enforcing; fixes ``"Permission denied"`` when executing ``/usr/libexec/qemu-kvm`` (`#81 <https://github.com/maglo/ansible-collection-qemu/issues/81>`_).
+- vms role - Replace Jinja2-interpolated task names (``"Create blank disk image for {{ item.name }}"``) with static names to comply with Ansible best practices (`#82 <https://github.com/maglo/ansible-collection-qemu/issues/82>`_).
+- vms role - Rename task ``"Enable and start VM service"`` to ``"Manage VM service state"`` to accurately reflect its conditional behaviour (`#83 <https://github.com/maglo/ansible-collection-qemu/issues/83>`_).
+
 v0.1.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ lsmod | grep kvm
 
 If the command returns `0` or the module is missing, check your BIOS/UEFI settings and ensure Intel VT-x / AMD-V is enabled. Nested virtualization (VMs inside VMs) also requires this flag to be exposed to the guest.
 
+### Package repositories
+
+The `maglo.qemu.host` role installs packages (`swtpm`, `swtpm-tools`, `socat`, and optionally `novnc`) that are only available from **EPEL** (Extra Packages for Enterprise Linux). Ensure EPEL — or an equivalent mirror — is enabled on the target host before running the collection:
+
+```bash
+dnf install epel-release
+```
+
+> **Note:** The collection intentionally does not manage EPEL setup. Automatically enabling EPEL is unsuitable for airgapped or restricted environments. Enable EPEL yourself or point your hosts at a compatible mirror.
+
 ## Quick Start
 
 ### Set up the host and create VMs
@@ -183,7 +193,7 @@ Graceful shutdown sends an ACPI powerdown via the QEMU monitor socket and waits 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `host_packages` | see defaults | Packages to install |
-| `host_libvirtd_enabled` | `true` | Enable and start libvirtd |
+| `host_libvirtd_enabled` | `false` | Enable and start libvirtd |
 | `host_vm_config_dir` | `/etc/qemu/vms` | VM config files directory |
 | `host_vm_image_dir` | `/var/lib/qemu/images` | VM disk images directory |
 | `host_service_user` | `qemu` | Service user |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: maglo
 name: qemu
-version: 0.1.0
+version: 0.1.1
 readme: README.md
 authors:
   - maglo

--- a/roles/host/README.md
+++ b/roles/host/README.md
@@ -8,6 +8,7 @@ The role installs QEMU/KVM packages, deploys systemd template units for managing
 
 - Ansible >= 2.15
 - Target hosts running Enterprise Linux 9 or 10
+- **EPEL** (or equivalent mirror) enabled on the target host — several packages installed by this role (`swtpm`, `swtpm-tools`, `socat`, and optionally `novnc`) are only available from EPEL. The collection intentionally does not manage EPEL setup to support airgapped deployments.
 
 ## Role Variables
 

--- a/roles/host/defaults/main.yml
+++ b/roles/host/defaults/main.yml
@@ -9,7 +9,7 @@ host_packages:
   - socat
 
 # Whether to enable and start libvirtd
-host_libvirtd_enabled: true
+host_libvirtd_enabled: false
 
 # Directory containing QEMU VM configuration files (one per VM)
 host_vm_config_dir: /etc/qemu/vms

--- a/roles/host/tasks/install.yml
+++ b/roles/host/tasks/install.yml
@@ -3,12 +3,14 @@
   ansible.builtin.dnf:
     name: "{{ host_packages }}"
     state: present
+  become: true
 
-- name: Enable and start libvirtd
+- name: Manage state of libvirtd service
   ansible.builtin.systemd_service:
     name: libvirtd
     enabled: "{{ host_libvirtd_enabled }}"
     state: "{{ 'started' if host_libvirtd_enabled else 'stopped' }}"
+  become: true
 
 - name: Create VM config directory
   ansible.builtin.file:
@@ -17,6 +19,7 @@
     owner: "{{ host_service_user }}"
     group: "{{ host_service_group }}"
     mode: "0755"
+  become: true
 
 - name: Create VM image directory
   ansible.builtin.file:
@@ -25,3 +28,4 @@
     owner: "{{ host_service_user }}"
     group: "{{ host_service_group }}"
     mode: "0755"
+  become: true

--- a/roles/host/tasks/novnc.yml
+++ b/roles/host/tasks/novnc.yml
@@ -3,11 +3,7 @@
   ansible.builtin.dnf:
     name: novnc
     state: present
-
-- name: Remove legacy single-instance noVNC service
-  ansible.builtin.file:
-    path: /etc/systemd/system/novnc.service
-    state: absent
+  become: true
 
 - name: Install noVNC systemd template unit
   ansible.builtin.template:
@@ -16,4 +12,5 @@
     owner: root
     group: root
     mode: '0644'
+  become: true
   notify: Reload systemd

--- a/roles/host/tasks/systemd.yml
+++ b/roles/host/tasks/systemd.yml
@@ -6,6 +6,7 @@
     owner: root
     group: root
     mode: "0644"
+  become: true
   notify:
     - Reload systemd
 
@@ -16,5 +17,6 @@
     owner: root
     group: root
     mode: "0644"
+  become: true
   notify:
     - Reload systemd

--- a/roles/vms/defaults/main.yml
+++ b/roles/vms/defaults/main.yml
@@ -31,11 +31,15 @@ vms_service_group: qemu
 # Whether VMs default to UEFI boot (can be overridden per VM with `uefi` key)
 vms_default_uefi: true
 
-# Path to OVMF firmware code (read-only, shared across VMs)
-vms_ovmf_code: /usr/share/edk2/ovmf/OVMF_CODE.fd
+# Path to OVMF firmware code (read-only, shared across VMs).
+# Defaults to the correct path for the detected OS major version (see vars/main.yml).
+# Override this variable if your firmware is installed in a non-standard location.
+vms_ovmf_code: "{{ _vms_ovmf_path_map[ansible_distribution_major_version | string]['code'] }}"
 
-# Path to OVMF vars template (copied per-VM for writable NVRAM)
-vms_ovmf_vars_template: /usr/share/edk2/ovmf/OVMF_VARS.fd
+# Path to OVMF vars template (copied per-VM for writable NVRAM).
+# Defaults to the correct path for the detected OS major version (see vars/main.yml).
+# Override this variable if your firmware is installed in a non-standard location.
+vms_ovmf_vars_template: "{{ _vms_ovmf_path_map[ansible_distribution_major_version | string]['vars'] }}"
 
 # Whether VMs default to TPM 2.0 emulation (per-VM override with `tpm` key)
 vms_default_tpm: false

--- a/roles/vms/files/selinux/qemu_vm.te
+++ b/roles/vms/files/selinux/qemu_vm.te
@@ -1,0 +1,12 @@
+module qemu_vm 1.0;
+
+require {
+    type unconfined_service_t;
+    type qemu_exec_t;
+    class file { execute execute_no_trans getattr map open read };
+}
+
+#============= unconfined_service_t ==============
+# Allow systemd-managed qemu-vm@.service (running as qemu user under
+# unconfined_service_t) to execute /usr/libexec/qemu-kvm (qemu_exec_t).
+allow unconfined_service_t qemu_exec_t:file { execute execute_no_trans getattr map open read };

--- a/roles/vms/tasks/destroy.yml
+++ b/roles/vms/tasks/destroy.yml
@@ -14,6 +14,7 @@
     name: "novnc@{{ item.name }}.service"
     state: stopped
     enabled: false
+  become: true
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
   failed_when: false
 
@@ -24,6 +25,7 @@
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     enabled: false
+  become: true
   failed_when: false
 
 - name: Stop and disable swtpm service
@@ -31,6 +33,7 @@
     name: "swtpm@{{ item.name }}.service"
     state: stopped
     enabled: false
+  become: true
   when: item.tpm | default(vms_default_tpm)
   failed_when: false
 
@@ -38,40 +41,48 @@
   ansible.builtin.file:
     path: "{{ vms_vm_config_dir }}/{{ item.name }}.conf"
     state: absent
+  become: true
 
 - name: Remove noVNC config file
   ansible.builtin.file:
     path: "{{ vms_vm_config_dir }}/novnc-{{ item.name }}.conf"
     state: absent
+  become: true
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
 
 - name: Remove disk image
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}"
     state: absent
+  become: true
 
 - name: Remove UEFI NVRAM file
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd"
     state: absent
+  become: true
   when: item.uefi | default(vms_default_uefi)
 
 - name: Remove per-VM runtime directory
   ansible.builtin.file:
     path: /var/lib/qemu/{{ item.name }}
     state: absent
+  become: true
 
 - name: Remove swtpm state directory
   ansible.builtin.file:
     path: "{{ vms_swtpm_state_dir }}/{{ item.name }}"
     state: absent
+  become: true
   when: item.tpm | default(vms_default_tpm)
 
 - name: Remove systemd drop-in directory
   ansible.builtin.file:
     path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
     state: absent
+  become: true
 
 - name: Reload systemd daemon
   ansible.builtin.systemd_service:
     daemon_reload: true
+  become: true

--- a/roles/vms/tasks/disk.yml
+++ b/roles/vms/tasks/disk.yml
@@ -1,18 +1,19 @@
 ---
 # Create blank disk images for VMs WITHOUT disk_image_url
-- name: Create blank disk image for {{ item.name }}
+- name: Create blank disk image
   ansible.builtin.command:
     cmd: >-
       qemu-img create -f {{ item.disk_format | default(vms_default_disk_format) }}
       {{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}
       {{ item.disk_size | default(vms_default_disk_size) }}
     creates: "{{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}"
+  become: true
   loop: "{{ _vms_active_vms | rejectattr('disk_image_url', 'defined') | list }}"
   loop_control:
     label: "{{ item.name }}"
 
 # Create overlay disk images for VMs WITH disk_image_url (using backing file)
-- name: Create overlay disk image with backing file for {{ item.name }}
+- name: Create overlay disk image with backing file
   ansible.builtin.command:
     cmd: >-
       qemu-img create -f {{ item.disk_format | default(vms_default_disk_format) }}
@@ -21,6 +22,7 @@
       {{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}
       {{ item.disk_size | default(vms_default_disk_size) }}
     creates: "{{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}"
+  become: true
   loop: "{{ _vms_active_vms | selectattr('disk_image_url', 'defined') | list }}"
   loop_control:
     label: "{{ item.name }}"
@@ -32,6 +34,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0644"
+  become: true
   loop: "{{ _vms_active_vms }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/vms/tasks/disk_image.yml
+++ b/roles/vms/tasks/disk_image.yml
@@ -13,6 +13,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0755"
+  become: true
   when: _vms_image_vms | length > 0
 
 # Download images (with checksum verification)
@@ -25,6 +26,7 @@
     group: "{{ vms_service_group }}"
     mode: "0644"
     force: false  # Don't re-download if file exists
+  become: true
   loop: "{{ _vms_image_vms }}"
   loop_control:
     label: "{{ item.name }} - {{ item.disk_image_url | basename }}"

--- a/roles/vms/tasks/firmware.yml
+++ b/roles/vms/tasks/firmware.yml
@@ -3,6 +3,7 @@
   ansible.builtin.dnf:
     name: edk2-ovmf
     state: present
+  become: true
   when: _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list | length > 0
         or (_vms_active_vms | rejectattr('uefi', 'defined') | list | length > 0 and vms_default_uefi)
 
@@ -15,6 +16,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0644"
+  become: true
   loop: "{{ _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list
             + (_vms_active_vms | rejectattr('uefi', 'defined') | list if vms_default_uefi else []) }}"
   loop_control:

--- a/roles/vms/tasks/main.yml
+++ b/roles/vms/tasks/main.yml
@@ -38,5 +38,8 @@
   ansible.builtin.import_tasks: usb_disk.yml
   when: _vms_active_vms | length > 0
 
+- name: Apply SELinux policy for QEMU VM service
+  ansible.builtin.import_tasks: selinux.yml
+
 - name: Generate VM config and manage service
   ansible.builtin.import_tasks: service.yml

--- a/roles/vms/tasks/monitor.yml
+++ b/roles/vms/tasks/monitor.yml
@@ -7,6 +7,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0755"
+  become: true
   loop: "{{ _vms_active_vms }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/vms/tasks/network.yml
+++ b/roles/vms/tasks/network.yml
@@ -6,6 +6,7 @@
     owner: root
     group: root
     mode: "0644"
+  become: true
   when: >-
     _vms_active_vms | selectattr('net_mode', 'defined')
                           | selectattr('net_mode', 'equalto', 'bridge')

--- a/roles/vms/tasks/novnc.yml
+++ b/roles/vms/tasks/novnc.yml
@@ -19,6 +19,7 @@
         owner: root
         group: root
         mode: '0644'
+      become: true
       loop: "{{ _vms_novnc_vms }}"
       loop_control:
         label: "{{ item.name }}"
@@ -29,6 +30,7 @@
         state: started
         enabled: true
         daemon_reload: true
+      become: true
       loop: "{{ _vms_novnc_vms }}"
       loop_control:
         label: "{{ item.name }}"

--- a/roles/vms/tasks/restart.yml
+++ b/roles/vms/tasks/restart.yml
@@ -4,6 +4,7 @@
   ansible.builtin.systemd_service:
     name: "novnc@{{ item.name }}.service"
     state: stopped
+  become: true
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
   failed_when: false
 
@@ -14,6 +15,7 @@
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: stopped
+  become: true
   when: item.tpm | default(vms_default_tpm)
   failed_when: false
 
@@ -21,6 +23,7 @@
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: started
+  become: true
   when: item.tpm | default(vms_default_tpm)
 
 - name: Start VM service
@@ -28,9 +31,11 @@
     name: "qemu-vm@{{ item.name }}.service"
     state: started
     daemon_reload: true
+  become: true
 
 - name: Start noVNC service if enabled
   ansible.builtin.systemd_service:
     name: "novnc@{{ item.name }}.service"
     state: started
+  become: true
   when: item.novnc_enabled | default(vms_default_novnc_enabled)

--- a/roles/vms/tasks/selinux.yml
+++ b/roles/vms/tasks/selinux.yml
@@ -1,0 +1,45 @@
+---
+# Install a minimal SELinux policy module to allow qemu-vm@.service to
+# execute /usr/libexec/qemu-kvm on EL9/EL10 with SELinux enforcing.
+# Skipped entirely when SELinux is Permissive or Disabled.
+
+- name: Check SELinux enforcement status
+  ansible.builtin.command: getenforce
+  register: _vms_selinux_status
+  changed_when: false
+  failed_when: false
+
+- name: Install SELinux policy utilities
+  ansible.builtin.dnf:
+    name:
+      - checkpolicy
+      - policycoreutils
+    state: present
+  become: true
+  when: _vms_selinux_status.stdout == 'Enforcing'
+
+- name: Copy qemu_vm SELinux policy source to remote
+  ansible.builtin.copy:
+    src: selinux/qemu_vm.te
+    dest: /tmp/qemu_vm.te
+    mode: "0644"
+  when: _vms_selinux_status.stdout == 'Enforcing'
+
+- name: Compile SELinux policy module
+  ansible.builtin.command:
+    cmd: checkmodule -M -m -o /tmp/qemu_vm.mod /tmp/qemu_vm.te
+  changed_when: true
+  when: _vms_selinux_status.stdout == 'Enforcing'
+
+- name: Package SELinux policy module
+  ansible.builtin.command:
+    cmd: semodule_package -o /tmp/qemu_vm.pp -m /tmp/qemu_vm.mod
+  changed_when: true
+  when: _vms_selinux_status.stdout == 'Enforcing'
+
+- name: Install SELinux policy module
+  ansible.builtin.command:
+    cmd: semodule -i /tmp/qemu_vm.pp
+  become: true
+  changed_when: true
+  when: _vms_selinux_status.stdout == 'Enforcing'

--- a/roles/vms/tasks/service.yml
+++ b/roles/vms/tasks/service.yml
@@ -6,6 +6,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0755"
+  become: true
 
 - name: Write per-VM config
   ansible.builtin.template:
@@ -14,20 +15,34 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0644"
+  become: true
   loop: "{{ _vms_active_vms }}"
   loop_control:
     label: "{{ item.name }}"
 
-- name: Enable and start VM service
+- name: Manage VM service state
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: "{{ item.state }}"
     enabled: true
     daemon_reload: true
+  become: true
   loop: "{{ _vms_active_vms }}"
   loop_control:
     label: "{{ item.name }}"
   when: (item.state | default('present')) in ['started', 'stopped']
+
+- name: Verify VM service is running
+  ansible.builtin.command:
+    cmd: systemctl is-active "qemu-vm@{{ item.name }}.service"
+  register: _vms_service_check
+  changed_when: false
+  failed_when: _vms_service_check.rc != 0
+  become: true
+  loop: "{{ _vms_active_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: (item.state | default('present')) == 'started'
 
 # ── Handle restart state ──────────────────────────────────
 - name: Restart VMs with state=restarted

--- a/roles/vms/tasks/shutdown.yml
+++ b/roles/vms/tasks/shutdown.yml
@@ -8,6 +8,7 @@
 - name: Check if VM is running
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
+  become: true
   register: vms_vm_service_status
 
 - name: Send ACPI shutdown via QEMU monitor
@@ -16,6 +17,7 @@
       set -o pipefail
       echo "system_powerdown" | socat - UNIX-CONNECT:/var/lib/qemu/{{ item.name }}/monitor.sock
     executable: /bin/bash
+  become: true
   when:
     - vms_vm_service_status.status.ActiveState == 'active'
     - vms_vm_service_status.status.SubState == 'running'
@@ -36,6 +38,7 @@
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: stopped
+  become: true
   when:
     - vms_vm_service_status.status.ActiveState == 'active'
     - (vms_graceful_shutdown_wait is failed or vms_acpi_shutdown is failed or vms_acpi_shutdown is skipped)
@@ -43,5 +46,6 @@
 - name: Verify VM is stopped
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
+  become: true
   register: vms_final_status
   failed_when: vms_final_status.status.ActiveState not in ['inactive', 'failed']

--- a/roles/vms/tasks/tpm.yml
+++ b/roles/vms/tasks/tpm.yml
@@ -19,6 +19,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0755"
+  become: true
   when: _vms_tpm_vms | length > 0
 
 - name: Create per-VM swtpm state directories
@@ -28,6 +29,7 @@
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0755"
+  become: true
   loop: "{{ _vms_tpm_vms }}"
   loop_control:
     label: "{{ item.name }}"
@@ -37,6 +39,7 @@
     name: "swtpm@{{ item.name }}.service"
     state: started
     enabled: true
+  become: true
   loop: "{{ _vms_tpm_vms }}"
   loop_control:
     label: "{{ item.name }}"
@@ -48,6 +51,7 @@
     mode: '0755'
     owner: root
     group: root
+  become: true
   loop: "{{ _vms_tpm_vms }}"
   loop_control:
     label: "{{ item.name }}"
@@ -59,6 +63,7 @@
     mode: '0644'
     owner: root
     group: root
+  become: true
   loop: "{{ _vms_tpm_vms }}"
   notify: Reload systemd
   loop_control:
@@ -67,4 +72,5 @@
 - name: Reload systemd daemon
   ansible.builtin.systemd_service:
     daemon_reload: true
+  become: true
   when: _vms_tpm_vms | length > 0

--- a/roles/vms/vars/main.yml
+++ b/roles/vms/vars/main.yml
@@ -1,0 +1,13 @@
+---
+# OS-specific OVMF firmware paths, keyed by ansible_distribution_major_version.
+# EL8 ships edk2-ovmf under /usr/share/OVMF/; EL9+ uses /usr/share/edk2/ovmf/.
+_vms_ovmf_path_map:
+  "8":
+    code: /usr/share/OVMF/OVMF_CODE.fd
+    vars: /usr/share/OVMF/OVMF_VARS.fd
+  "9":
+    code: /usr/share/edk2/ovmf/OVMF_CODE.fd
+    vars: /usr/share/edk2/ovmf/OVMF_VARS.fd
+  "10":
+    code: /usr/share/edk2/ovmf/OVMF_CODE.fd
+    vars: /usr/share/edk2/ovmf/OVMF_VARS.fd


### PR DESCRIPTION
## Summary

Fixes all 10 bugs identified during manual testing of v0.1.0 (see #84 for the full test report). Bumps version to 0.1.1.

- #74 — `become: true` added to all privileged tasks in `host` and `vms` roles
- #75 — `host_libvirtd_enabled` default changed to `false`
- #76 — Libvirtd task renamed to "Manage state of libvirtd service"
- #77 — Dead "Remove legacy single-instance noVNC service" task removed
- #78 — OVMF firmware paths now auto-detected by OS version (configurable)
- #79 — Play now fails if `qemu-vm@<name>.service` doesn't reach active state
- #80 — EPEL documented as a prerequisite in README and role docs
- #81 — Minimal SELinux policy module shipped for EL9/EL10 enforcing mode
- #82 — Jinja2-interpolated task names replaced with static names
- #83 — VM service task renamed to "Manage VM service state"

## Test plan

- [ ] Run `ansible-lint` — no new violations
- [ ] Run `ansible-test sanity` — passes
- [ ] Verify `host` role runs without `become: true` at playbook level
- [ ] Verify `qemu-vm@test.service` starts successfully on EL9 with SELinux enforcing
- [ ] Verify OVMF path resolves correctly on EL8 and EL9
- [ ] Verify play fails when a VM service fails to start

🤖 Generated with [Claude Code](https://claude.com/claude-code)