### PR TITLE
Fix Galaxy docs: include playbooks and add metadata URLs

### DIFF
--- a/changelogs/fragments/88-fix-galaxy-docs.yaml
+++ b/changelogs/fragments/88-fix-galaxy-docs.yaml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - >-
+    collection - Include playbooks in the collection tarball so README links
+    resolve on Galaxy
+    (https://github.com/maglo/ansible-collection-qemu/issues/88).
+  - >-
+    collection - Add ``documentation``, ``homepage``, and ``issues`` URLs to
+    ``galaxy.yml`` metadata
+    (https://github.com/maglo/ansible-collection-qemu/issues/88).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,9 @@ tags:
   - systemd
   - novnc
 repository: https://github.com/maglo/ansible-collection-qemu
+documentation: https://github.com/maglo/ansible-collection-qemu/blob/main/README.md
+homepage: https://github.com/maglo/ansible-collection-qemu
+issues: https://github.com/maglo/ansible-collection-qemu/issues
 dependencies: {}
 build_ignore:
   - .github
@@ -25,5 +28,4 @@ build_ignore:
   - Makefile
   - molecule
   - tests
-  - playbooks
   - "roles/*/molecule"


### PR DESCRIPTION
## Summary
- Remove `playbooks` from `build_ignore` in `galaxy.yml` so playbook files are included in the published collection tarball and README links resolve on Galaxy
- Add `documentation`, `homepage`, and `issues` URLs to `galaxy.yml` metadata for Galaxy navigation

Closes #88

## Test plan
- [x] `ansible-galaxy collection build` succeeds
- [x] Tarball contains `playbooks/` (5 files) and `docs/docsite/` (config + 3 RST guides)
- [x] `antsibull-changelog lint` passes
- [ ] CI pipeline passes (lint, sanity, docs, molecule, changelog)
- [ ] After next release + Galaxy publish, verify docs page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)