### PR TITLE
Remove libvirtd management and libvirt package

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ Graceful shutdown sends an ACPI powerdown via the QEMU monitor socket and waits 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `host_packages` | see defaults | Packages to install |
-| `host_libvirtd_enabled` | `false` | Enable and start libvirtd |
 | `host_vm_config_dir` | `/etc/qemu/vms` | VM config files directory |
 | `host_vm_image_dir` | `/var/lib/qemu/images` | VM disk images directory |
 | `host_service_user` | `qemu` | Service user |

--- a/changelogs/fragments/91-remove-libvirtd.yaml
+++ b/changelogs/fragments/91-remove-libvirtd.yaml
@@ -1,0 +1,6 @@
+---
+breaking_changes:
+  - "host - Remove ``host_libvirtd_enabled`` variable and ``libvirt`` from default
+    packages. The collection's libvirt-free design means libvirtd was never needed
+    for VM management. Users who need libvirt can add it to ``host_packages``
+    (closes #91)."

--- a/docs/docsite/rst/guide_host.rst
+++ b/docs/docsite/rst/guide_host.rst
@@ -22,7 +22,7 @@ Installation
 Basic setup
 -----------
 
-The simplest playbook installs QEMU/KVM packages, enables ``libvirtd``, and deploys a systemd template unit for managing VMs:
+The simplest playbook installs QEMU/KVM packages and deploys a systemd template unit for managing VMs:
 
 .. code-block:: yaml
 
@@ -32,11 +32,10 @@ The simplest playbook installs QEMU/KVM packages, enables ``libvirtd``, and depl
 
 This will:
 
-1. Install ``qemu-kvm``, ``qemu-img``, ``libvirt``, ``swtpm``, and ``swtpm-tools``.
-2. Enable and start ``libvirtd``.
-3. Create the VM configuration directory (``/etc/qemu/vms``).
-4. Create the VM image directory (``/var/lib/qemu/images``).
-5. Deploy the ``qemu-vm@.service`` systemd template unit.
+1. Install ``qemu-kvm``, ``qemu-img``, ``swtpm``, ``swtpm-tools``, and ``socat``.
+2. Create the VM configuration directory (``/etc/qemu/vms``).
+3. Create the VM image directory (``/var/lib/qemu/images``).
+4. Deploy the ``qemu-vm@.service`` systemd template unit.
 
 Customising packages
 --------------------
@@ -52,7 +51,6 @@ Override ``host_packages`` to control which packages are installed:
            host_packages:
              - qemu-kvm
              - qemu-img
-             - libvirt
 
 Customising directories
 -----------------------

--- a/docs/docsite/rst/guide_manual_testing.rst
+++ b/docs/docsite/rst/guide_manual_testing.rst
@@ -80,7 +80,7 @@ Verify that the ``host`` role installs packages and deploys systemd template uni
 .. code-block:: bash
 
    # Packages installed
-   rpm -q qemu-kvm qemu-img libvirt swtpm swtpm-tools socat
+   rpm -q qemu-kvm qemu-img swtpm swtpm-tools socat
 
    # Systemd units deployed
    systemctl cat qemu-vm@.service
@@ -88,9 +88,6 @@ Verify that the ``host`` role installs packages and deploys systemd template uni
 
    # Directories created
    ls -la /etc/qemu/vms /var/lib/qemu/images
-
-   # libvirtd running
-   systemctl status libvirtd
 
 Test 2: Host role — noVNC
 --------------------------

--- a/roles/host/README.md
+++ b/roles/host/README.md
@@ -14,8 +14,7 @@ The role installs QEMU/KVM packages, deploys systemd template units for managing
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `host_packages` | `[qemu-kvm, qemu-img, libvirt, swtpm, swtpm-tools, socat]` | Packages to install for QEMU/KVM host |
-| `host_libvirtd_enabled` | `true` | Whether to enable and start libvirtd |
+| `host_packages` | `[qemu-kvm, qemu-img, swtpm, swtpm-tools, socat]` | Packages to install for QEMU/KVM host |
 | `host_vm_config_dir` | `/etc/qemu/vms` | Directory containing VM configuration files (one `.conf` per VM) |
 | `host_vm_image_dir` | `/var/lib/qemu/images` | Directory containing VM disk images |
 | `host_service_user` | `qemu` | User for the QEMU systemd service |

--- a/roles/host/defaults/main.yml
+++ b/roles/host/defaults/main.yml
@@ -3,13 +3,9 @@
 host_packages:
   - qemu-kvm
   - qemu-img
-  - libvirt
   - swtpm
   - swtpm-tools
   - socat
-
-# Whether to enable and start libvirtd
-host_libvirtd_enabled: false
 
 # Directory containing QEMU VM configuration files (one per VM)
 host_vm_config_dir: /etc/qemu/vms

--- a/roles/host/handlers/main.yml
+++ b/roles/host/handlers/main.yml
@@ -2,8 +2,3 @@
 - name: Reload systemd
   ansible.builtin.systemd_service:
     daemon_reload: true
-
-- name: Restart libvirtd
-  ansible.builtin.systemd_service:
-    name: libvirtd
-    state: restarted

--- a/roles/host/meta/argument_specs.yml
+++ b/roles/host/meta/argument_specs.yml
@@ -13,13 +13,8 @@ argument_specs:
         default:
           - qemu-kvm
           - qemu-img
-          - libvirt
           - swtpm
           - swtpm-tools
-      host_libvirtd_enabled:
-        description: Whether to enable and start libvirtd.
-        type: bool
-        default: true
       host_vm_config_dir:
         description: Directory containing QEMU VM configuration files (one C(.conf) per VM).
         type: path

--- a/roles/host/molecule/default/converge.yml
+++ b/roles/host/molecule/default/converge.yml
@@ -3,4 +3,3 @@
   hosts: all
   roles:
     - role: host
-      host_libvirtd_enabled: false

--- a/roles/host/molecule/default/verify.yml
+++ b/roles/host/molecule/default/verify.yml
@@ -14,7 +14,6 @@
       loop:
         - qemu-kvm
         - qemu-img
-        - libvirt
         - swtpm
         - swtpm-tools
 
@@ -123,15 +122,6 @@
           - "'Before=qemu-vm@%i.service' in content"
           - "'/usr/bin/swtpm socket' in content"
           - "'/var/lib/swtpm/%i' in content"
-
-    # ── libvirtd is disabled ──────────────────────────────────
-    - name: Check libvirtd is not enabled
-      ansible.builtin.systemd_service:
-        name: libvirtd
-        enabled: false
-      check_mode: true
-      register: libvirtd_check
-      failed_when: libvirtd_check.changed
 
     # ── noVNC should not exist (negative test) ────────────────
     - name: Stat noVNC directory

--- a/roles/host/molecule/novnc/converge.yml
+++ b/roles/host/molecule/novnc/converge.yml
@@ -3,5 +3,4 @@
   hosts: all
   roles:
     - role: host
-      host_libvirtd_enabled: false
       host_novnc_enabled: true

--- a/roles/host/molecule/novnc/verify.yml
+++ b/roles/host/molecule/novnc/verify.yml
@@ -14,7 +14,6 @@
       loop:
         - qemu-kvm
         - qemu-img
-        - libvirt
         - swtpm
         - swtpm-tools
 

--- a/roles/host/tasks/install.yml
+++ b/roles/host/tasks/install.yml
@@ -5,13 +5,6 @@
     state: present
   become: true
 
-- name: Manage state of libvirtd service
-  ansible.builtin.systemd_service:
-    name: libvirtd
-    enabled: "{{ host_libvirtd_enabled }}"
-    state: "{{ 'started' if host_libvirtd_enabled else 'stopped' }}"
-  become: true
-
 - name: Create VM config directory
   ansible.builtin.file:
     path: "{{ host_vm_config_dir }}"

--- a/roles/vms/molecule/lifecycle/converge.yml
+++ b/roles/vms/molecule/lifecycle/converge.yml
@@ -1,9 +1,6 @@
 ---
 - name: Converge - Lifecycle operations
   hosts: all
-  vars:
-    # Use qcow2 format for Docker testing (KVM not available)
-    host_libvirtd_enabled: false
   tasks:
     # Include host role first
     - name: Include host role

--- a/roles/vms/molecule/novnc/converge.yml
+++ b/roles/vms/molecule/novnc/converge.yml
@@ -3,7 +3,6 @@
   hosts: all
   roles:
     - role: host
-      host_libvirtd_enabled: false
       host_novnc_enabled: true
     - role: vms
       vms_list:


### PR DESCRIPTION
## Summary
- Remove `host_libvirtd_enabled` variable, libvirtd service task, and `Restart libvirtd` handler
- Remove `libvirt` from default `host_packages` list
- Update all documentation (role README, root README, docsite guides, manual testing guide)
- Clean up molecule tests: remove `host_libvirtd_enabled: false` overrides and libvirtd/libvirt verification

## Rationale

The collection's core design principle is **Libvirt-free** — VMs are driven directly by `qemu-system-*` via systemd template units. Installing `libvirt` and managing `libvirtd` contradicts this philosophy and adds unnecessary overhead. Users who need libvirt for other purposes can add it back via `host_packages`.

## Breaking change

`host_libvirtd_enabled` is removed. Users relying on this variable to manage libvirtd should add `libvirt` to `host_packages` and manage the service separately.

Closes #91

## Test plan
- [ ] CI gate passes (lint, sanity, docs, molecule, changelog)
- [ ] `host/default` molecule scenario passes without libvirt references
- [ ] `host/novnc` molecule scenario passes without libvirt references

🤖 Generated with [Claude Code](https://claude.com/claude-code)