### PR TITLE
feat(vms): add UEFI Secure Boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ systemctl status qemu-vm@web01
 
 - UEFI boot with OVMF firmware, enabled by default
 - Per-VM writable NVRAM (`OVMF_VARS.fd`) copied automatically
+- **Secure Boot**: Enable per VM with `secure_boot: true` — uses `OVMF_CODE.secboot.fd` with pre-enrolled Microsoft/OVMF keys and SMM
 - Disable per VM with `uefi: false`
 
 ### TPM 2.0 emulation
@@ -208,6 +209,7 @@ Graceful shutdown sends an ACPI powerdown via the QEMU monitor socket and waits 
 | `vms_default_disk_size` | `20G` | Default disk size |
 | `vms_default_disk_format` | `qcow2` | Default disk format |
 | `vms_default_uefi` | `true` | UEFI boot by default |
+| `vms_default_secure_boot` | `false` | UEFI Secure Boot by default |
 | `vms_default_tpm` | `false` | TPM emulation by default |
 | `vms_default_net_mode` | `user` | Default networking mode |
 | `vms_default_memory` | `2G` | Default memory |
@@ -227,6 +229,7 @@ Graceful shutdown sends an ACPI powerdown via the QEMU monitor socket and waits 
 | `disk_image_url` | no | — | URL to a QCOW2 image (creates overlay) |
 | `disk_image_checksum` | no | — | `sha256:...` checksum for URL image |
 | `uefi` | no | `vms_default_uefi` | UEFI boot |
+| `secure_boot` | no | `vms_default_secure_boot` | UEFI Secure Boot |
 | `tpm` | no | `vms_default_tpm` | TPM 2.0 emulation |
 | `net_mode` | no | `vms_default_net_mode` | `user` or `bridge` |
 | `net_bridge` | no | `br0` | Bridge device (bridge mode) |

--- a/changelogs/fragments/90-secure-boot.yaml
+++ b/changelogs/fragments/90-secure-boot.yaml
@@ -1,0 +1,8 @@
+minor_changes:
+  - >-
+    vms role - Add UEFI Secure Boot support via ``secure_boot`` per-VM key
+    and ``vms_default_secure_boot`` global default.
+    When enabled, the role uses OVMF Secure Boot firmware with pre-enrolled
+    keys, adds ``smm=on`` to the QEMU machine line, and sets the
+    ``cfi.pflash01`` secure property
+    (https://github.com/maglo/ansible-collection-qemu/issues/90).

--- a/docs/docsite/rst/guide_manual_testing.rst
+++ b/docs/docsite/rst/guide_manual_testing.rst
@@ -174,7 +174,30 @@ Verify UEFI boot is configured correctly (enabled by default, disable explicitly
    ls /var/lib/qemu/images/uefi-on_VARS.fd
    ls /var/lib/qemu/images/uefi-off_VARS.fd 2>&1 | grep "No such file"
 
-Test 5: TPM 2.0 emulation
+Test 5: UEFI Secure Boot
+--------------------------
+
+.. code-block:: yaml
+
+   vms_list:
+     - name: secboot-vm
+       disk_size: 5G
+       secure_boot: true
+       state: present
+
+**Verify:**
+
+.. code-block:: bash
+
+   # Config contains SMM and secure pflash args
+   grep "smm=on" /etc/qemu/vms/secboot-vm.conf
+   grep "OVMF_CODE.secboot.fd" /etc/qemu/vms/secboot-vm.conf
+   grep "cfi.pflash01" /etc/qemu/vms/secboot-vm.conf
+
+   # Secure boot marker exists
+   ls /var/lib/qemu/images/secboot-vm_VARS.fd.secboot
+
+Test 6: TPM 2.0 emulation
 ---------------------------
 
 .. code-block:: yaml
@@ -204,7 +227,7 @@ Test 5: TPM 2.0 emulation
    # VM config contains TPM args
    grep chardev /etc/qemu/vms/tpm-vm.conf
 
-Test 6: Networking
+Test 7: Networking
 -------------------
 
 **User-mode (default):**
@@ -242,7 +265,7 @@ Test 6: Networking
    # VM config uses bridge netdev
    grep "netdev bridge" /etc/qemu/vms/bridge-vm.conf
 
-Test 7: noVNC web console
+Test 8: noVNC web console
 --------------------------
 
 .. code-block:: yaml
@@ -275,7 +298,7 @@ Test 7: noVNC web console
 
    # Connect browser to http://<host>:6080/vnc.html
 
-Test 8: URL-based disk image provisioning
+Test 9: URL-based disk image provisioning
 ------------------------------------------
 
 .. code-block:: yaml
@@ -300,8 +323,8 @@ Test 8: URL-based disk image provisioning
    ansible-playbook -i inventory.yml test_url.yml
    # Verify mtime of cache file is unchanged
 
-Test 9: USB disk attachment
-----------------------------
+Test 10: USB disk attachment
+-----------------------------
 
 .. code-block:: bash
 
@@ -324,7 +347,7 @@ Test 9: USB disk attachment
    grep "qemu-xhci" /etc/qemu/vms/usb-vm.conf
    grep "usb-storage,drive=usb0,bootindex=1" /etc/qemu/vms/usb-vm.conf
 
-Test 10: VM lifecycle
+Test 11: VM lifecycle
 ----------------------
 
 Run all lifecycle states on a test VM (requires KVM to be available for ``started``/``stopped``/``restarted``):

--- a/roles/vms/README.md
+++ b/roles/vms/README.md
@@ -29,6 +29,9 @@ The role creates disk images, configures UEFI firmware, TPM emulation, and netwo
 | `vms_default_uefi` | `true` | Whether VMs default to UEFI boot when not specified per VM |
 | `vms_ovmf_code` | `/usr/share/edk2/ovmf/OVMF_CODE.fd` | Path to OVMF firmware code file |
 | `vms_ovmf_vars_template` | `/usr/share/edk2/ovmf/OVMF_VARS.fd` | Path to OVMF vars template (copied per VM) |
+| `vms_default_secure_boot` | `false` | Whether VMs default to UEFI Secure Boot (per-VM override with `secure_boot` key) |
+| `vms_ovmf_code_secboot` | `/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd` | Path to OVMF Secure Boot firmware code file |
+| `vms_ovmf_vars_secboot_template` | `/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd` | Path to OVMF Secure Boot vars template (pre-enrolled keys) |
 | `vms_default_tpm` | `false` | Whether VMs default to TPM 2.0 emulation (per-VM override with `tpm` key) |
 | `vms_swtpm_state_dir` | `/var/lib/swtpm` | Base directory for per-VM swtpm state |
 | `vms_default_net_mode` | `user` | Default networking mode (`user` or `bridge`) |
@@ -53,6 +56,7 @@ Each entry in `vms_list` is a dictionary with the following keys:
 | `disk_image_url` | no | — | URL to a qcow2 image to download and use as a backing file |
 | `disk_image_checksum` | no | — | SHA256 checksum for the downloaded image (format: `sha256:abc123...`) |
 | `uefi` | no | `vms_default_uefi` | Whether to enable UEFI boot for this VM |
+| `secure_boot` | no | `vms_default_secure_boot` | Enable UEFI Secure Boot (requires UEFI) |
 | `tpm` | no | `vms_default_tpm` | Enable TPM 2.0 emulation via swtpm |
 | `net_mode` | no | `vms_default_net_mode` | Networking mode: `user` or `bridge` |
 | `net_bridge` | no | `vms_default_net_bridge` | Bridge device (only used when `net_mode` is `bridge`) |

--- a/roles/vms/defaults/main.yml
+++ b/roles/vms/defaults/main.yml
@@ -41,6 +41,15 @@ vms_ovmf_code: "{{ _vms_ovmf_path_map[(ansible_distribution_major_version | defa
 # Override this variable if your firmware is installed in a non-standard location.
 vms_ovmf_vars_template: "{{ _vms_ovmf_path_map[(ansible_distribution_major_version | default('9')) | string]['vars'] }}"
 
+# Whether VMs default to UEFI Secure Boot (per-VM override with `secure_boot` key)
+vms_default_secure_boot: false
+
+# Path to OVMF Secure Boot firmware code (read-only, shared across VMs)
+vms_ovmf_code_secboot: /usr/share/edk2/ovmf/OVMF_CODE.secboot.fd
+
+# Path to OVMF Secure Boot vars template (pre-enrolled Microsoft/OVMF keys, copied per-VM)
+vms_ovmf_vars_secboot_template: /usr/share/edk2/ovmf/OVMF_VARS.secboot.fd
+
 # Whether VMs default to TPM 2.0 emulation (per-VM override with `tpm` key)
 vms_default_tpm: false
 

--- a/roles/vms/meta/argument_specs.yml
+++ b/roles/vms/meta/argument_specs.yml
@@ -16,6 +16,7 @@ argument_specs:
             C(disk_image_url) (URL to qcow2 image to use as backing file),
             C(disk_image_checksum) (SHA256 checksum for image verification),
             C(uefi) (overrides C(vms_default_uefi)),
+            C(secure_boot) (overrides C(vms_default_secure_boot)),
             C(tpm) (overrides C(vms_default_tpm)),
             C(net_mode) (overrides C(vms_default_net_mode)),
             C(net_bridge) (overrides C(vms_default_net_bridge)),
@@ -59,6 +60,12 @@ argument_specs:
             type: str
           uefi:
             description: Whether to enable UEFI boot for this VM. Overrides C(vms_default_uefi).
+            type: bool
+          secure_boot:
+            description: >-
+              Enable UEFI Secure Boot for this VM. Overrides C(vms_default_secure_boot).
+              Uses C(OVMF_CODE.secboot.fd) with pre-enrolled Microsoft/OVMF keys and enables
+              SMM (System Management Mode). Requires UEFI to be enabled.
             type: bool
           tpm:
             description: Enable TPM 2.0 emulation for this VM via swtpm. Overrides C(vms_default_tpm).
@@ -185,6 +192,23 @@ argument_specs:
           C(/usr/share/edk2/ovmf/OVMF_VARS.fd) on EL9+.
           Override this variable if your firmware is installed in a non-standard location.
         type: path
+      vms_default_secure_boot:
+        description: >-
+          Whether VMs default to UEFI Secure Boot when not specified per-VM.
+          Uses Secure Boot firmware with pre-enrolled Microsoft/OVMF keys.
+        type: bool
+        default: false
+      vms_ovmf_code_secboot:
+        description: >-
+          Path to the OVMF Secure Boot firmware code file (read-only, shared across VMs).
+        type: path
+        default: /usr/share/edk2/ovmf/OVMF_CODE.secboot.fd
+      vms_ovmf_vars_secboot_template:
+        description: >-
+          Path to the OVMF Secure Boot vars template file with pre-enrolled keys
+          (copied per-VM for writable NVRAM).
+        type: path
+        default: /usr/share/edk2/ovmf/OVMF_VARS.secboot.fd
       vms_default_tpm:
         description: Whether VMs default to TPM 2.0 emulation. Can be overridden per VM with C(tpm) key.
         type: bool

--- a/roles/vms/molecule/default/converge.yml
+++ b/roles/vms/molecule/default/converge.yml
@@ -42,3 +42,7 @@
           usb_disk_image: /tmp/test-usb-installer.iso
           usb_boot_priority: false
           state: present
+        - name: testvm-secboot
+          disk_size: 1G
+          secure_boot: true
+          state: present

--- a/roles/vms/molecule/default/verify.yml
+++ b/roles/vms/molecule/default/verify.yml
@@ -222,6 +222,68 @@
           - "'-device usb-storage,drive=usb0' in _content"
           - "'bootindex=1' not in _content"
 
+    # ── Secure Boot firmware ────────────────────────────────
+    - name: Stat OVMF_CODE.secboot.fd
+      ansible.builtin.stat:
+        path: /usr/share/edk2/ovmf/OVMF_CODE.secboot.fd
+      register: ovmf_code_secboot
+
+    - name: Assert OVMF_CODE.secboot.fd exists
+      ansible.builtin.assert:
+        that:
+          - ovmf_code_secboot.stat.exists
+
+    - name: Stat per-VM secboot NVRAM file
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm-secboot_VARS.fd
+      register: secboot_nvram_file
+
+    - name: Assert secboot NVRAM file properties
+      ansible.builtin.assert:
+        that:
+          - secboot_nvram_file.stat.exists
+          - secboot_nvram_file.stat.pw_name == 'qemu'
+          - secboot_nvram_file.stat.gr_name == 'qemu'
+          - secboot_nvram_file.stat.mode == '0644'
+
+    - name: Stat secure boot marker file
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm-secboot_VARS.fd.secboot
+      register: secboot_marker
+
+    - name: Assert secure boot marker exists
+      ansible.builtin.assert:
+        that:
+          - secboot_marker.stat.exists
+
+    - name: Verify no secure boot marker for standard UEFI VM
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm_VARS.fd.secboot
+      register: testvm_no_secboot_marker
+
+    - name: Assert standard UEFI VM has no secure boot marker
+      ansible.builtin.assert:
+        that:
+          - not testvm_no_secboot_marker.stat.exists
+
+    # ── VM config — testvm-secboot (Secure Boot + UEFI) ───
+    - name: Read testvm-secboot config
+      ansible.builtin.slurp:
+        src: /etc/qemu/vms/testvm-secboot.conf
+      register: testvm_secboot_conf
+
+    - name: Assert testvm-secboot config has secure boot args
+      vars:
+        _content: "{{ testvm_secboot_conf.content | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - "'-name testvm-secboot' in _content"
+          - "'-machine q35,accel=kvm,smm=on' in _content"
+          - "'OVMF_CODE.secboot.fd' in _content"
+          - "'testvm-secboot_VARS.fd' in _content"
+          - "'-global driver=cfi.pflash01,property=secure,value=on' in _content"
+          - "'-vnc :' in _content"
+
     # ── bridge.conf ──────────────────────────────────────────
     - name: Stat bridge.conf
       ansible.builtin.stat:
@@ -256,6 +318,11 @@
       ansible.builtin.stat:
         path: /var/lib/qemu/images/testvm_VARS.fd
       register: nvram_before_rerun
+
+    - name: Record secboot NVRAM modification time
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm-secboot_VARS.fd
+      register: secboot_nvram_before_rerun
 
     - name: Record swtpm state directory modification time
       ansible.builtin.stat:
@@ -304,6 +371,10 @@
             usb_disk_image: /tmp/test-usb-installer.iso
             usb_boot_priority: false
             state: present
+          - name: testvm-secboot
+            disk_size: 1G
+            secure_boot: true
+            state: present
 
     - name: Record image modification time after re-run
       ansible.builtin.stat:
@@ -314,6 +385,11 @@
       ansible.builtin.stat:
         path: /var/lib/qemu/images/testvm_VARS.fd
       register: nvram_after_rerun
+
+    - name: Record secboot NVRAM modification time after re-run
+      ansible.builtin.stat:
+        path: /var/lib/qemu/images/testvm-secboot_VARS.fd
+      register: secboot_nvram_after_rerun
 
     - name: Record swtpm state directory modification time after re-run
       ansible.builtin.stat:
@@ -339,6 +415,11 @@
       ansible.builtin.assert:
         that:
           - swtpm_before_rerun.stat.mtime == swtpm_after_rerun.stat.mtime
+
+    - name: Assert secboot NVRAM was not overwritten
+      ansible.builtin.assert:
+        that:
+          - secboot_nvram_before_rerun.stat.mtime == secboot_nvram_after_rerun.stat.mtime
 
     - name: Assert config was not rewritten
       ansible.builtin.assert:

--- a/roles/vms/tasks/destroy.yml
+++ b/roles/vms/tasks/destroy.yml
@@ -63,6 +63,12 @@
   become: true
   when: item.uefi | default(vms_default_uefi)
 
+- name: Remove secure boot marker file
+  ansible.builtin.file:
+    path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
+    state: absent
+  when: item.uefi | default(vms_default_uefi)
+
 - name: Remove per-VM runtime directory
   ansible.builtin.file:
     path: /var/lib/qemu/{{ item.name }}

--- a/roles/vms/tasks/firmware.yml
+++ b/roles/vms/tasks/firmware.yml
@@ -7,17 +7,75 @@
   when: _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list | length > 0
         or (_vms_active_vms | rejectattr('uefi', 'defined') | list | length > 0 and vms_default_uefi)
 
+# Build the list of UEFI VMs with resolved secure_boot flag
+- name: Identify UEFI VMs
+  ansible.builtin.set_fact:
+    _vms_uefi_vms: >-
+      {{ _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list
+         + (_vms_active_vms | rejectattr('uefi', 'defined') | list if vms_default_uefi else []) }}
+
+- name: Validate secure_boot requires UEFI
+  ansible.builtin.assert:
+    that:
+      - item.uefi | default(vms_default_uefi)
+    fail_msg: >-
+      VM '{{ item.name }}' has secure_boot enabled but uefi is disabled.
+      Secure Boot requires UEFI firmware. Set uefi: true or remove secure_boot: true.
+  loop: "{{ _vms_active_vms | selectattr('secure_boot', 'defined') | selectattr('secure_boot') | list
+            + (_vms_active_vms | rejectattr('secure_boot', 'defined') | list if vms_default_secure_boot else []) }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# Check secure boot marker files to detect state transitions
+- name: Check secure boot marker files
+  ansible.builtin.stat:
+    path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
+  register: _vms_secboot_markers
+  loop: "{{ _vms_uefi_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# Copy OVMF_VARS per-VM using the correct template based on secure_boot setting.
+# force=true when the secure boot state changed (marker doesn't match desired state).
 - name: Copy OVMF_VARS per-VM
   ansible.builtin.copy:
-    src: "{{ vms_ovmf_vars_template }}"
-    dest: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd"
+    src: "{{ _vars_template }}"
+    dest: "{{ vms_image_dir }}/{{ item.0.name }}_VARS.fd"
     remote_src: true
-    force: false
+    force: "{{ _state_changed }}"
     owner: "{{ vms_service_user }}"
     group: "{{ vms_service_group }}"
     mode: "0644"
   become: true
-  loop: "{{ _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list
-            + (_vms_active_vms | rejectattr('uefi', 'defined') | list if vms_default_uefi else []) }}"
+  vars:
+    _sb: "{{ item.0.secure_boot | default(vms_default_secure_boot) | bool }}"
+    _vars_template: "{{ vms_ovmf_vars_secboot_template if _sb else vms_ovmf_vars_template }}"
+    _marker_exists: "{{ item.1.stat.exists }}"
+    _state_changed: "{{ _sb != _marker_exists }}"
+  loop: "{{ _vms_uefi_vms | zip(_vms_secboot_markers.results) | list }}"
+  loop_control:
+    label: "{{ item.0.name }}"
+
+# Manage secure boot marker files to track state
+- name: Create secure boot marker
+  ansible.builtin.file:
+    path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
+    state: touch
+    owner: "{{ vms_service_user }}"
+    group: "{{ vms_service_group }}"
+    mode: "0644"
+    modification_time: preserve
+    access_time: preserve
+  loop: "{{ _vms_uefi_vms | selectattr('secure_boot', 'defined') | selectattr('secure_boot') | list
+            + (_vms_uefi_vms | rejectattr('secure_boot', 'defined') | list if vms_default_secure_boot else []) }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Remove secure boot marker for standard UEFI VMs
+  ansible.builtin.file:
+    path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
+    state: absent
+  loop: "{{ _vms_uefi_vms | selectattr('secure_boot', 'defined') | rejectattr('secure_boot') | list
+            + (_vms_uefi_vms | rejectattr('secure_boot', 'defined') | list if not vms_default_secure_boot else []) }}"
   loop_control:
     label: "{{ item.name }}"

--- a/roles/vms/templates/vm.conf.j2
+++ b/roles/vms/templates/vm.conf.j2
@@ -3,12 +3,17 @@
 {% set _memory = item.memory | default(vms_default_memory) %}
 {% set _cpus = item.cpus | default(vms_default_cpus) %}
 {% set _uefi = item.uefi | default(vms_default_uefi) %}
+{% set _secure_boot = item.secure_boot | default(vms_default_secure_boot) %}
 {% set _tpm = item.tpm | default(vms_default_tpm) %}
 {% set _net_mode = item.net_mode | default(vms_default_net_mode) %}
 {% set _mac = item.mac_address | default('52:54:00:' ~ (item.name | hash('md5'))[0:2] ~ ':' ~ (item.name | hash('md5'))[2:4] ~ ':' ~ (item.name | hash('md5'))[4:6]) %}
 {% set _args = [] %}
 {% set _ = _args.append('-name ' ~ item.name) %}
+{% if _secure_boot %}
+{% set _ = _args.append('-machine q35,accel=kvm,smm=on') %}
+{% else %}
 {% set _ = _args.append('-machine q35,accel=kvm') %}
+{% endif %}
 {% set _ = _args.append('-m ' ~ _memory) %}
 {% set _ = _args.append('-smp ' ~ _cpus) %}
 {% set _ = _args.append('-nographic') %}
@@ -34,8 +39,14 @@
 {% endif %}
 {% endif %}
 {% if _uefi %}
+{% if _secure_boot %}
+{% set _ = _args.append('-drive if=pflash,format=raw,readonly=on,file=' ~ vms_ovmf_code_secboot) %}
+{% set _ = _args.append('-drive if=pflash,format=raw,file=' ~ vms_image_dir ~ '/' ~ item.name ~ '_VARS.fd') %}
+{% set _ = _args.append('-global driver=cfi.pflash01,property=secure,value=on') %}
+{% else %}
 {% set _ = _args.append('-drive if=pflash,format=raw,readonly=on,file=' ~ vms_ovmf_code) %}
 {% set _ = _args.append('-drive if=pflash,format=raw,file=' ~ vms_image_dir ~ '/' ~ item.name ~ '_VARS.fd') %}
+{% endif %}
 {% endif %}
 {% if _tpm %}
 {% set _ = _args.append('-chardev socket,id=chrtpm,path=' ~ vms_swtpm_state_dir ~ '/' ~ item.name ~ '/swtpm.sock') %}


### PR DESCRIPTION
## Summary
- Add `secure_boot` per-VM key and `vms_default_secure_boot` global default for UEFI Secure Boot
- When enabled, uses OVMF Secure Boot firmware with pre-enrolled keys, `smm=on`, and `cfi.pflash01` secure property
- Marker file tracks state transitions to preserve NVRAM idempotency
- Includes molecule tests for config verification and idempotency

## Changes
- **`roles/vms/defaults/main.yml`** — add `vms_default_secure_boot`, `vms_ovmf_code_secboot`, `vms_ovmf_vars_secboot_template`
- **`roles/vms/meta/argument_specs.yml`** — add `secure_boot` per-VM option and 3 global variables
- **`roles/vms/tasks/firmware.yml`** — secure boot firmware provisioning with marker-based state tracking
- **`roles/vms/templates/vm.conf.j2`** — conditional `smm=on`, secboot firmware path, `cfi.pflash01` secure property
- **`roles/vms/tasks/destroy.yml`** — cleanup `.secboot` marker on VM destruction
- **`roles/vms/molecule/default/converge.yml`** — add `testvm-secboot` VM
- **`roles/vms/molecule/default/verify.yml`** — secure boot verification and idempotency assertions
- **Documentation** — updated README, role README, and manual testing guide

## Test plan
- [ ] CI molecule tests pass (new `testvm-secboot` VM exercised)
- [ ] Ansible-lint passes
- [ ] Idempotency: NVRAM not overwritten on re-run

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)