### PR TITLE
docs: require fetch+rebase on origin/main before starting work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,12 @@
 ## Git conventions
 
 - **Never commit directly to main/master.** Always create a feature branch and open a PR for changes.
+- **Before starting any work**, fetch from origin and rebase your branch on `origin/main`:
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+  Do not skip this step — unrebased branches cannot be merged.
 - Keep commits atomic. Don't introduce something broken or incorrect and fix it in a follow-up commit within the same PR.
 - PRs should preferably close a GitHub issue. Create an issue first if one doesn't exist, and reference it in the PR body (e.g., `Closes #123`).
 - Do not include coding session URLs in commit messages.


### PR DESCRIPTION
## Summary

- Adds a mandatory pre-work step to the Git conventions section of `AGENTS.md` requiring agents to run `git fetch origin && git rebase origin/main` before starting any work

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)