### PR TITLE
fix(vms): fail early and add systemd dependency when novnc_enabled

### DIFF
--- a/changelogs/fragments/100-novnc-prerequisite.yaml
+++ b/changelogs/fragments/100-novnc-prerequisite.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "vms - Fail early when ``novnc_enabled`` is set but the ``novnc@.service`` template is absent, and add a
+    systemd drop-in so the VM unit depends on its noVNC service (closes #100)."

--- a/roles/vms/tasks/novnc.yml
+++ b/roles/vms/tasks/novnc.yml
@@ -12,6 +12,37 @@
 - name: Configure noVNC for VMs
   when: _vms_novnc_vms | length > 0
   block:
+    - name: Verify noVNC systemd template exists
+      ansible.builtin.stat:
+        path: /etc/systemd/system/novnc@.service
+      register: _vms_novnc_template
+      failed_when: not _vms_novnc_template.stat.exists
+
+    - name: Create systemd drop-in directory for noVNC-dependent VMs
+      ansible.builtin.file:
+        path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+      become: true
+      loop: "{{ _vms_novnc_vms }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Deploy noVNC dependency override for noVNC-enabled VMs
+      ansible.builtin.template:
+        src: qemu-vm-novnc-dependency.conf.j2
+        dest: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d/novnc-dependency.conf"
+        mode: '0644'
+        owner: root
+        group: root
+      become: true
+      loop: "{{ _vms_novnc_vms }}"
+      notify: Reload systemd
+      loop_control:
+        label: "{{ item.name }}"
+
     - name: Deploy per-VM noVNC environment files
       ansible.builtin.template:
         src: novnc-env.conf.j2

--- a/roles/vms/templates/qemu-vm-novnc-dependency.conf.j2
+++ b/roles/vms/templates/qemu-vm-novnc-dependency.conf.j2
@@ -1,0 +1,5 @@
+# Managed by Ansible - vms role
+# noVNC dependency for VM {{ item.name }}
+[Unit]
+After=novnc@{{ item.name }}.service
+Requires=novnc@{{ item.name }}.service


### PR DESCRIPTION
## Summary

- Add a prerequisite `stat` check in `novnc.yml` that fails the play early if `novnc@.service` template is missing (modelled after the existing swtpm check in `tpm.yml`)
- Add a new systemd drop-in template `qemu-vm-novnc-dependency.conf.j2` that adds `Requires=` / `After=novnc@<vm>.service` to the VM unit
- Drop-in is deployed before the VM service is started, ensuring systemd enforces the dependency

Closes #100

## Test plan

- [ ] Run `vms` role with `novnc_enabled: true` when host role was **not** run with `host_novnc_enabled: true` — expect play to fail with clear message about missing template
- [ ] Run with `host_novnc_enabled: true` first, then `novnc_enabled: true` — confirm drop-in is deployed and VM starts with noVNC dependency
- [ ] Verify `systemctl cat qemu-vm@<name>.service` shows the drop-in `Requires`/`After` directives
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)