### PR TITLE
fix(docs): replace relative README links with absolute GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ If you need an Ansible-driven, version-controlled alternative to manually runnin
 
 | Role | Description |
 |------|-------------|
-| [`maglo.qemu.host`](roles/host/README.md) | Install QEMU/KVM packages, deploy systemd template units for VMs, and optionally set up noVNC |
-| [`maglo.qemu.vms`](roles/vms/README.md) | Create and manage QEMU/KVM virtual machines — disk images, UEFI, TPM, networking, noVNC, USB, and lifecycle |
+| [`maglo.qemu.host`](https://github.com/maglo/ansible-collection-qemu/blob/main/roles/host/README.md) | Install QEMU/KVM packages, deploy systemd template units for VMs, and optionally set up noVNC |
+| [`maglo.qemu.vms`](https://github.com/maglo/ansible-collection-qemu/blob/main/roles/vms/README.md) | Create and manage QEMU/KVM virtual machines — disk images, UEFI, TPM, networking, noVNC, USB, and lifecycle |
 
 ## Supported Platforms
 
@@ -247,17 +247,17 @@ Graceful shutdown sends an ACPI powerdown via the QEMU monitor socket and waits 
 
 ## Example Playbooks
 
-See the [example playbooks](playbooks/) directory for ready-to-use examples:
+See the [example playbooks](https://github.com/maglo/ansible-collection-qemu/tree/main/playbooks/) directory for ready-to-use examples:
 
 | Playbook | Description |
 |----------|-------------|
-| [`basic_host.yml`](playbooks/basic_host.yml) | Minimal host setup |
-| [`vms.yml`](playbooks/vms.yml) | Host setup + basic VM creation |
-| [`vms_with_novnc.yml`](playbooks/vms_with_novnc.yml) | Host + VMs with noVNC enabled |
+| [`basic_host.yml`](https://github.com/maglo/ansible-collection-qemu/blob/main/playbooks/basic_host.yml) | Minimal host setup |
+| [`vms.yml`](https://github.com/maglo/ansible-collection-qemu/blob/main/playbooks/vms.yml) | Host setup + basic VM creation |
+| [`vms_with_novnc.yml`](https://github.com/maglo/ansible-collection-qemu/blob/main/playbooks/vms_with_novnc.yml) | Host + VMs with noVNC enabled |
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and workflow guidelines.
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/maglo/ansible-collection-qemu/blob/main/CONTRIBUTING.md) for development setup, testing, and workflow guidelines.
 
 ## License
 

--- a/changelogs/fragments/101-readme-galaxy-links.yaml
+++ b/changelogs/fragments/101-readme-galaxy-links.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Replace relative README links with absolute GitHub URLs so they resolve correctly on Ansible Galaxy (closes #101)."


### PR DESCRIPTION
## Summary

- Replace all relative links in `README.md` with absolute `https://github.com/maglo/ansible-collection-qemu/blob/main/...` URLs
- Affects role links (`roles/host/README.md`, `roles/vms/README.md`), playbook links, and `CONTRIBUTING.md`

Closes #101

## Test plan

- [ ] Open the collection page on [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/maglo/qemu/) after publishing — all links in the README resolve correctly
- [ ] Verify links still work on GitHub (absolute URLs are valid there too)
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)