### PR TITLE
fix: exclude playbooks from Galaxy tarball until docs are complete

### DIFF
--- a/changelogs/fragments/102-galaxy-hide-playbooks.yaml
+++ b/changelogs/fragments/102-galaxy-hide-playbooks.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Exclude ``playbooks/`` from the Galaxy tarball until playbook documentation is complete (closes #102)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -29,3 +29,4 @@ build_ignore:
   - molecule
   - tests
   - "roles/*/molecule"
+  - playbooks


### PR DESCRIPTION
## Summary

- Add `playbooks` to `build_ignore` in `galaxy.yml`
- Playbooks currently appear on the Galaxy page with empty documentation (no synopsis), creating a poor user experience
- They remain available in the GitHub repository; this only affects the published tarball

Blocked by #49 (playbook documentation). Once #49 is resolved, revert this change.

Closes #102

## Test plan

- [ ] Run `make build` and verify `playbooks/` is absent from the resulting tarball (`tar tzf maglo-qemu-*.tar.gz | grep playbook`)
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)