### PR TITLE
fix(vms): use static name for TPM drop-in directory task

### DIFF
--- a/changelogs/fragments/103-tpm-task-name.yaml
+++ b/changelogs/fragments/103-tpm-task-name.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "vms - Replace Jinja2 loop variable in TPM drop-in task ``name:`` field with a static string to avoid
+    literal ``{{ item.name }}`` appearing in loop output (closes #103)."

--- a/roles/vms/tasks/tpm.yml
+++ b/roles/vms/tasks/tpm.yml
@@ -44,7 +44,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Create systemd drop-in directory for qemu-vm@{{ item.name }}
+- name: Create systemd drop-in directory for TPM-enabled VMs
   ansible.builtin.file:
     path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
     state: directory


### PR DESCRIPTION
## Summary

- Replace `{{ item.name }}` in the `name:` field of the "Create systemd drop-in directory" task in `tpm.yml` with a static string
- Ansible does not reliably interpolate loop variables in task names; `loop_control: label:` already identifies the VM in the output

Closes #103

## Test plan

- [ ] Run `vms` role with TPM-enabled VMs and verify task output shows `"Create systemd drop-in directory for TPM-enabled VMs"` rather than literal `{{ item.name }}`
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)