### PR TITLE
fix(host,vms): add become: true to Reload systemd handlers

### DIFF
--- a/changelogs/fragments/104-systemd-handler-become.yaml
+++ b/changelogs/fragments/104-systemd-handler-become.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "host, vms - Add ``become: true`` to ``Reload systemd`` handlers so ``daemon_reload`` reaches the system
+    D-Bus socket and does not time out when the play runs without top-level ``become`` (closes #104)."

--- a/roles/host/handlers/main.yml
+++ b/roles/host/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: Reload systemd
   ansible.builtin.systemd_service:
     daemon_reload: true
+  become: true

--- a/roles/vms/handlers/main.yml
+++ b/roles/vms/handlers/main.yml
@@ -2,3 +2,4 @@
 - name: Reload systemd
   ansible.builtin.systemd_service:
     daemon_reload: true
+  become: true


### PR DESCRIPTION
## Summary

- Add `become: true` to the `Reload systemd` handler in both `roles/host/handlers/main.yml` and `roles/vms/handlers/main.yml`
- `daemon_reload: true` must communicate with the system D-Bus socket, which requires root; without `become` the handler fails with "Method call timed out"

Closes #104

## Test plan

- [ ] Run the `host` or `vms` role in a play without top-level `become: true` and confirm the handler executes without timeout
- [ ] Verify `systemctl daemon-reload` succeeds after a systemd unit file change
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)