### PR TITLE
fix(vms): create monitor socket directory for state: present

### DIFF
--- a/changelogs/fragments/105-monitor-runtime-dir.yaml
+++ b/changelogs/fragments/105-monitor-runtime-dir.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - "vms - Create per-VM runtime directory for the monitor socket when ``state: present``, not only for
+    started/stopped/restarted, so ``systemctl start qemu-vm@<name>`` works without a second playbook run
+    (closes #105)."

--- a/roles/vms/tasks/monitor.yml
+++ b/roles/vms/tasks/monitor.yml
@@ -11,4 +11,4 @@
   loop: "{{ _vms_active_vms }}"
   loop_control:
     label: "{{ item.name }}"
-  when: (item.state | default('present')) in ['started', 'stopped', 'restarted']
+  when: (item.state | default('present')) != 'absent'


### PR DESCRIPTION
## Summary

- Change the `when` condition in `monitor.yml` from an allowlist (`in ['started', 'stopped', 'restarted']`) to `!= 'absent'`
- The runtime directory (`/var/lib/qemu/<name>/`) now gets created for `state: present` as well
- Fixes `systemctl start qemu-vm@<name>` failing with "No such file or directory" when the VM was deployed with `state: present`

Closes #105

## Test plan

- [ ] Deploy a VM with `state: present` — verify `/var/lib/qemu/<name>/` is created
- [ ] Run `systemctl start qemu-vm@<name>` manually — confirm it starts without socket errors
- [ ] Deploy a VM with `state: absent` — verify the directory creation is skipped
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)