### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ maglo.qemu Release Notes
 
 .. contents:: Topics
 
+v0.2.1
+======
+
+Bugfixes
+--------
+
+- Replace relative README links with absolute GitHub URLs so they resolve correctly on Ansible Galaxy (closes #101).
+- host - Fix SELinux policy to target ``init_t`` instead of ``unconfined_service_t`` and add ``swtpm_exec_t`` execute rule, resolving VMs failing to start with SELinux enforcing on EL9 (closes #99).
+- host - Move SELinux policy installation from ``vms`` role to ``host`` role where it architecturally belongs (closes #98).
+- host, vms - Add ``become: true`` to ``Reload systemd`` handlers so ``daemon_reload`` reaches the system D-Bus socket and does not time out when the play runs without top-level ``become`` (closes #104).
+- vms - Add ``-cpu host`` flag to QEMU args so guests expose the host CPU feature set; without it QEMU defaults to ``qemu64``, causing a fatal glibc error on EL9 (closes #106).
+- vms - Create per-VM runtime directory for the monitor socket when ``state: present``, not only for started/stopped/restarted, so ``systemctl start qemu-vm@<name>`` works without a second playbook run (closes #105).
+- vms - Fail early when ``novnc_enabled`` is set but the ``novnc@.service`` template is absent, and add a systemd drop-in so the VM unit depends on its noVNC service (closes #100).
+- vms - Replace Jinja2 loop variable in TPM drop-in task ``name:`` field with a static string to avoid literal ``{{ item.name }}`` appearing in loop output (closes #103).
+
 v0.2.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -132,3 +132,38 @@ releases:
     - 91-remove-libvirtd.yaml
     - release-0.2.0-summary.yaml
     release_date: '2026-02-22'
+  0.2.1:
+    changes:
+      bugfixes:
+      - 'Replace relative README links with absolute GitHub URLs so they resolve correctly
+        on Ansible Galaxy (closes #101).'
+      - 'host - Fix SELinux policy to target ``init_t`` instead of ``unconfined_service_t``
+        and add ``swtpm_exec_t`` execute rule, resolving VMs failing to start with
+        SELinux enforcing on EL9 (closes #99).'
+      - 'host - Move SELinux policy installation from ``vms`` role to ``host`` role
+        where it architecturally belongs (closes #98).'
+      - 'host, vms - Add ``become: true`` to ``Reload systemd`` handlers so ``daemon_reload``
+        reaches the system D-Bus socket and does not time out when the play runs without
+        top-level ``become`` (closes #104).'
+      - 'vms - Add ``-cpu host`` flag to QEMU args so guests expose the host CPU feature
+        set; without it QEMU defaults to ``qemu64``, causing a fatal glibc error on
+        EL9 (closes #106).'
+      - 'vms - Create per-VM runtime directory for the monitor socket when ``state:
+        present``, not only for started/stopped/restarted, so ``systemctl start qemu-vm@<name>``
+        works without a second playbook run (closes #105).'
+      - 'vms - Fail early when ``novnc_enabled`` is set but the ``novnc@.service``
+        template is absent, and add a systemd drop-in so the VM unit depends on its
+        noVNC service (closes #100).'
+      - 'vms - Replace Jinja2 loop variable in TPM drop-in task ``name:`` field with
+        a static string to avoid literal ``{{ item.name }}`` appearing in loop output
+        (closes #103).'
+    fragments:
+    - 100-novnc-prerequisite.yaml
+    - 101-readme-galaxy-links.yaml
+    - 102-galaxy-hide-playbooks.yaml
+    - 103-tpm-task-name.yaml
+    - 104-systemd-handler-become.yaml
+    - 105-monitor-runtime-dir.yaml
+    - 109-cpu-host-flag.yaml
+    - 98-99-selinux-move-and-fix.yaml
+    release_date: '2026-02-24'

--- a/changelogs/fragments/100-novnc-prerequisite.yaml
+++ b/changelogs/fragments/100-novnc-prerequisite.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "vms - Fail early when ``novnc_enabled`` is set but the ``novnc@.service`` template is absent, and add a
-    systemd drop-in so the VM unit depends on its noVNC service (closes #100)."

--- a/changelogs/fragments/101-readme-galaxy-links.yaml
+++ b/changelogs/fragments/101-readme-galaxy-links.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "Replace relative README links with absolute GitHub URLs so they resolve correctly on Ansible Galaxy (closes #101)."

--- a/changelogs/fragments/102-galaxy-hide-playbooks.yaml
+++ b/changelogs/fragments/102-galaxy-hide-playbooks.yaml
@@ -1,3 +1,0 @@
----
-trivial:
-  - "Exclude ``playbooks/`` from the Galaxy tarball until playbook documentation is complete (closes #102)."

--- a/changelogs/fragments/103-tpm-task-name.yaml
+++ b/changelogs/fragments/103-tpm-task-name.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "vms - Replace Jinja2 loop variable in TPM drop-in task ``name:`` field with a static string to avoid
-    literal ``{{ item.name }}`` appearing in loop output (closes #103)."

--- a/changelogs/fragments/104-systemd-handler-become.yaml
+++ b/changelogs/fragments/104-systemd-handler-become.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "host, vms - Add ``become: true`` to ``Reload systemd`` handlers so ``daemon_reload`` reaches the system
-    D-Bus socket and does not time out when the play runs without top-level ``become`` (closes #104)."

--- a/changelogs/fragments/105-monitor-runtime-dir.yaml
+++ b/changelogs/fragments/105-monitor-runtime-dir.yaml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - "vms - Create per-VM runtime directory for the monitor socket when ``state: present``, not only for
-    started/stopped/restarted, so ``systemctl start qemu-vm@<name>`` works without a second playbook run
-    (closes #105)."

--- a/changelogs/fragments/109-cpu-host-flag.yaml
+++ b/changelogs/fragments/109-cpu-host-flag.yaml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - "vms - Add ``-cpu host`` flag to QEMU args so guests expose the host CPU
-    feature set; without it QEMU defaults to ``qemu64``, causing a fatal glibc
-    error on EL9 (closes #106)."

--- a/changelogs/fragments/98-99-selinux-move-and-fix.yaml
+++ b/changelogs/fragments/98-99-selinux-move-and-fix.yaml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - "host - Move SELinux policy installation from ``vms`` role to ``host`` role where it architecturally belongs (closes #98)."
-  - "host - Fix SELinux policy to target ``init_t`` instead of ``unconfined_service_t`` and add ``swtpm_exec_t``
-    execute rule, resolving VMs failing to start with SELinux enforcing on EL9 (closes #99)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: maglo
 name: qemu
-version: 0.2.0
+version: 0.2.1
 readme: README.md
 authors:
   - maglo


### PR DESCRIPTION
## Release v0.2.1

Patch release compiling all bug fixes from the 0.2.0 manual test report (issue #108).

### Bugfixes included

- **#106** — `-cpu host` flag to prevent kernel panic on AlmaLinux 9
- **#99** — SELinux policy fixed for `init_t` context on EL9 (VMs fail to start)
- **#98** — SELinux policy moved from `vms` to `host` role
- **#100** — Fail early + systemd dependency when `novnc_enabled` but template missing
- **#104** — `become: true` added to `Reload systemd` handlers
- **#105** — Monitor socket directory created for `state: present`
- **#103** — Static task name in TPM drop-in task (Jinja2 literal rendering)
- **#101** — README relative links replaced with absolute GitHub URLs
- **#102** — Playbooks excluded from Galaxy tarball until docs complete

### Post-merge steps (maintainer)

After merging this PR:

```bash
git checkout main && git pull
git tag -a v0.2.1 -m "Release v0.2.1"
git push origin v0.2.1
```

The release workflow will create a GitHub Release and attach the tarball automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)