### PR TITLE
feat(vms): include VM name in per-VM loop task names

### DIFF
--- a/changelogs/fragments/128-loop-task-names.yaml
+++ b/changelogs/fragments/128-loop-task-names.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "vms - include VM name in per-VM loop task names for clearer playbook output
+    when managing multiple VMs (closes #128)."

--- a/roles/vms/tasks/cloud_init.yml
+++ b/roles/vms/tasks/cloud_init.yml
@@ -23,7 +23,7 @@
           genisoimage not found on the host.
           Run the maglo.qemu.host role to install it.
 
-    - name: Create cloud-init staging directory
+    - name: Create cloud-init staging directory for {{ item.name }}
       ansible.builtin.file:
         path: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}"
         state: directory
@@ -35,7 +35,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Write cloud-init meta-data
+    - name: Write cloud-init meta-data for {{ item.name }}
       ansible.builtin.copy:
         dest: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}/meta-data"
         content: >-
@@ -50,7 +50,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Write cloud-init user-data
+    - name: Write cloud-init user-data for {{ item.name }}
       ansible.builtin.copy:
         dest: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}/user-data"
         content: "{{ item.cloud_init_user_data | default('#cloud-config\n') }}"
@@ -63,7 +63,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Write cloud-init network-config
+    - name: Write cloud-init network-config for {{ item.name }}
       ansible.builtin.copy:
         dest: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}/network-config"
         content: "{{ item.cloud_init_network_config }}"
@@ -77,7 +77,7 @@
         label: "{{ item.name }}"
       when: item.cloud_init_network_config is defined
 
-    - name: Stat cloud-init seed ISOs
+    - name: Stat cloud-init seed ISO for {{ item.name }}
       ansible.builtin.stat:
         path: "{{ vms_image_dir }}/{{ item.name }}-seed.iso"
       register: _vms_iso_stats
@@ -109,7 +109,7 @@
         or (item.cloud_init_network_config is defined
             and _vms_network_config_results.results[ansible_loop.index0].changed)
 
-    - name: Set ownership of cloud-init seed ISO
+    - name: Set ownership of cloud-init seed ISO for {{ item.name }}
       ansible.builtin.file:
         path: "{{ vms_image_dir }}/{{ item.name }}-seed.iso"
         owner: "{{ vms_service_user }}"

--- a/roles/vms/tasks/destroy.yml
+++ b/roles/vms/tasks/destroy.yml
@@ -1,7 +1,7 @@
 ---
 # Destroy VM and remove all artifacts
 # Requires force_destroy: true to prevent accidental data loss
-- name: Validate force_destroy flag is set
+- name: Validate force_destroy for {{ item.name }}
   ansible.builtin.assert:
     that:
       - item.force_destroy is defined
@@ -9,7 +9,7 @@
     fail_msg: "Cannot destroy VM '{{ item.name }}': force_destroy must be set to true"
     success_msg: "force_destroy confirmed for VM '{{ item.name }}'"
 
-- name: Stop noVNC service
+- name: Stop noVNC service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "novnc@{{ item.name }}.service"
     state: stopped
@@ -18,7 +18,7 @@
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
   failed_when: false
 
-- name: Stop and disable VM service
+- name: Stop and disable VM service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: stopped
@@ -26,10 +26,10 @@
   become: true
   failed_when: false
 
-- name: Gracefully shut down VM
+- name: Gracefully shut down {{ item.name }}
   ansible.builtin.include_tasks: shutdown.yml
 
-- name: Stop and disable swtpm service
+- name: Stop and disable swtpm service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: stopped
@@ -38,70 +38,70 @@
   when: item.tpm | default(vms_default_tpm)
   failed_when: false
 
-- name: Remove VM config file
+- name: Remove VM config file for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_vm_config_dir }}/{{ item.name }}.conf"
     state: absent
   become: true
 
-- name: Remove noVNC config file
+- name: Remove noVNC config file for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_vm_config_dir }}/novnc-{{ item.name }}.conf"
     state: absent
   become: true
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
 
-- name: Remove disk image
+- name: Remove disk image for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}.{{ item.disk_format | default(vms_default_disk_format) }}"
     state: absent
   become: true
 
-- name: Remove cloud-init seed ISO
+- name: Remove cloud-init seed ISO for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}-seed.iso"
     state: absent
   become: true
 
-- name: Remove cloud-init staging directory
+- name: Remove cloud-init staging directory for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}"
     state: absent
   become: true
 
-- name: Remove UEFI NVRAM file
+- name: Remove UEFI NVRAM file for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd"
     state: absent
   become: true
   when: item.uefi | default(vms_default_uefi)
 
-- name: Remove secure boot marker file
+- name: Remove secure boot marker file for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
     state: absent
   when: item.uefi | default(vms_default_uefi)
 
-- name: Remove per-VM runtime directory
+- name: Remove per-VM runtime directory for {{ item.name }}
   ansible.builtin.file:
     path: /var/lib/qemu/{{ item.name }}
     state: absent
   become: true
 
-- name: Remove swtpm state directory
+- name: Remove swtpm state directory for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_swtpm_state_dir }}/{{ item.name }}"
     state: absent
   become: true
   when: item.tpm | default(vms_default_tpm)
 
-- name: Remove systemd drop-in directory
+- name: Remove systemd drop-in directory for {{ item.name }}
   ansible.builtin.file:
     path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
     state: absent
   become: true
 
-- name: Reload systemd daemon
+- name: Reload systemd daemon after destroying {{ item.name }}
   ansible.builtin.systemd_service:
     daemon_reload: true
   become: true

--- a/roles/vms/tasks/firmware.yml
+++ b/roles/vms/tasks/firmware.yml
@@ -6,7 +6,7 @@
       {{ _vms_active_vms | selectattr('uefi', 'defined') | selectattr('uefi') | list
          + (_vms_active_vms | rejectattr('uefi', 'defined') | list if vms_default_uefi else []) }}
 
-- name: Validate secure_boot requires UEFI
+- name: Validate secure_boot requires UEFI for {{ item.name }}
   ansible.builtin.assert:
     that:
       - item.uefi | default(vms_default_uefi)
@@ -19,7 +19,7 @@
     label: "{{ item.name }}"
 
 # Check secure boot marker files to detect state transitions
-- name: Check secure boot marker files
+- name: Check secure boot marker for {{ item.name }}
   ansible.builtin.stat:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
   register: _vms_secboot_markers
@@ -29,7 +29,7 @@
 
 # Copy OVMF_VARS per-VM using the correct template based on secure_boot setting.
 # force=true when the secure boot state changed (marker doesn't match desired state).
-- name: Copy OVMF_VARS per-VM
+- name: Copy OVMF_VARS for {{ item.0.name }}
   ansible.builtin.copy:
     src: "{{ _vars_template }}"
     dest: "{{ vms_image_dir }}/{{ item.0.name }}_VARS.fd"
@@ -49,7 +49,7 @@
     label: "{{ item.0.name }}"
 
 # Manage secure boot marker files to track state
-- name: Create secure boot marker
+- name: Create secure boot marker for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
     state: touch
@@ -63,7 +63,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Remove secure boot marker for standard UEFI VMs
+- name: Remove secure boot marker for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_image_dir }}/{{ item.name }}_VARS.fd.secboot"
     state: absent

--- a/roles/vms/tasks/monitor.yml
+++ b/roles/vms/tasks/monitor.yml
@@ -1,6 +1,6 @@
 ---
 # Configure QEMU monitor sockets for VM lifecycle management
-- name: Create per-VM runtime directories for monitor sockets
+- name: Create monitor socket directory for {{ item.name }}
   ansible.builtin.file:
     path: /var/lib/qemu/{{ item.name }}
     state: directory

--- a/roles/vms/tasks/novnc.yml
+++ b/roles/vms/tasks/novnc.yml
@@ -18,7 +18,7 @@
       register: _vms_novnc_template
       failed_when: not _vms_novnc_template.stat.exists
 
-    - name: Create systemd drop-in directory for noVNC-dependent VMs
+    - name: Create systemd drop-in directory for {{ item.name }}
       ansible.builtin.file:
         path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
         state: directory
@@ -30,7 +30,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Deploy noVNC dependency override for noVNC-enabled VMs
+    - name: Deploy noVNC dependency override for {{ item.name }}
       ansible.builtin.template:
         src: qemu-vm-novnc-dependency.conf.j2
         dest: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d/novnc-dependency.conf"
@@ -43,7 +43,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Deploy per-VM noVNC environment files
+    - name: Deploy noVNC environment file for {{ item.name }}
       ansible.builtin.template:
         src: novnc-env.conf.j2
         dest: "{{ vms_vm_config_dir }}/novnc-{{ item.name }}.conf"
@@ -55,7 +55,7 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Enable and start per-VM noVNC services
+    - name: Enable and start noVNC service for {{ item.name }}
       ansible.builtin.systemd_service:
         name: "novnc@{{ item.name }}.service"
         state: started

--- a/roles/vms/tasks/restart.yml
+++ b/roles/vms/tasks/restart.yml
@@ -1,6 +1,6 @@
 ---
 # Restart a VM with graceful shutdown
-- name: Stop noVNC service if enabled
+- name: Stop noVNC service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "novnc@{{ item.name }}.service"
     state: stopped
@@ -8,10 +8,10 @@
   when: item.novnc_enabled | default(vms_default_novnc_enabled)
   failed_when: false
 
-- name: Gracefully shut down VM
+- name: Gracefully shut down {{ item.name }}
   ansible.builtin.include_tasks: shutdown.yml
 
-- name: Stop swtpm service if enabled
+- name: Stop swtpm service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: stopped
@@ -19,21 +19,21 @@
   when: item.tpm | default(vms_default_tpm)
   failed_when: false
 
-- name: Start swtpm service if enabled
+- name: Start swtpm service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: started
   become: true
   when: item.tpm | default(vms_default_tpm)
 
-- name: Start VM service
+- name: Start VM service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: started
     daemon_reload: true
   become: true
 
-- name: Start noVNC service if enabled
+- name: Start noVNC service for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "novnc@{{ item.name }}.service"
     state: started

--- a/roles/vms/tasks/service.yml
+++ b/roles/vms/tasks/service.yml
@@ -8,7 +8,7 @@
     mode: "0755"
   become: true
 
-- name: Write per-VM config
+- name: Write config for {{ item.name }}
   ansible.builtin.template:
     src: vm.conf.j2
     dest: "{{ vms_vm_config_dir }}/{{ item.name }}.conf"
@@ -20,7 +20,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Manage VM service state
+- name: Manage service state for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: "{{ item.state }}"
@@ -32,7 +32,7 @@
     label: "{{ item.name }}"
   when: (item.state | default('present')) in ['started', 'stopped']
 
-- name: Verify VM service is running
+- name: Verify service is running for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
   register: _vms_service_check

--- a/roles/vms/tasks/shutdown.yml
+++ b/roles/vms/tasks/shutdown.yml
@@ -5,7 +5,7 @@
   ansible.builtin.set_fact:
     vms_shutdown_timeout: "{{ item.shutdown_timeout | default(vms_default_shutdown_timeout) }}"
 
-- name: Check if {{ item.name }} is running
+- name: Check VM service status for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
   become: true
@@ -34,7 +34,7 @@
   failed_when: false
   register: vms_graceful_shutdown_wait
 
-- name: Force stop {{ item.name }} if graceful shutdown timed out
+- name: Force stop VM service if graceful shutdown timed out for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: stopped
@@ -43,7 +43,7 @@
     - vms_vm_service_status.status.ActiveState == 'active'
     - (vms_graceful_shutdown_wait is failed or vms_acpi_shutdown is failed or vms_acpi_shutdown is skipped)
 
-- name: Verify {{ item.name }} is stopped
+- name: Verify VM service is stopped for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
   become: true

--- a/roles/vms/tasks/shutdown.yml
+++ b/roles/vms/tasks/shutdown.yml
@@ -1,17 +1,17 @@
 ---
 # Gracefully shut down a VM using QEMU monitor ACPI powerdown
 # Falls back to systemctl stop if timeout exceeded
-- name: Determine shutdown timeout
+- name: Determine shutdown timeout for {{ item.name }}
   ansible.builtin.set_fact:
     vms_shutdown_timeout: "{{ item.shutdown_timeout | default(vms_default_shutdown_timeout) }}"
 
-- name: Check if VM is running
+- name: Check if {{ item.name }} is running
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
   become: true
   register: vms_vm_service_status
 
-- name: Send ACPI shutdown via QEMU monitor
+- name: Send ACPI shutdown to {{ item.name }}
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
@@ -25,7 +25,7 @@
   changed_when: true
   register: vms_acpi_shutdown
 
-- name: Wait for graceful shutdown
+- name: Wait for graceful shutdown of {{ item.name }}
   ansible.builtin.wait_for:
     path: /var/lib/qemu/{{ item.name }}/monitor.sock
     state: absent
@@ -34,7 +34,7 @@
   failed_when: false
   register: vms_graceful_shutdown_wait
 
-- name: Force stop VM if graceful shutdown timed out
+- name: Force stop {{ item.name }} if graceful shutdown timed out
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
     state: stopped
@@ -43,7 +43,7 @@
     - vms_vm_service_status.status.ActiveState == 'active'
     - (vms_graceful_shutdown_wait is failed or vms_acpi_shutdown is failed or vms_acpi_shutdown is skipped)
 
-- name: Verify VM is stopped
+- name: Verify {{ item.name }} is stopped
   ansible.builtin.systemd_service:
     name: "qemu-vm@{{ item.name }}.service"
   become: true

--- a/roles/vms/tasks/tpm.yml
+++ b/roles/vms/tasks/tpm.yml
@@ -22,7 +22,7 @@
   become: true
   when: _vms_tpm_vms | length > 0
 
-- name: Create per-VM swtpm state directories
+- name: Create swtpm state directory for {{ item.name }}
   ansible.builtin.file:
     path: "{{ vms_swtpm_state_dir }}/{{ item.name }}"
     state: directory
@@ -34,7 +34,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Enable and start swtpm for TPM-enabled VMs
+- name: Enable and start swtpm for {{ item.name }}
   ansible.builtin.systemd_service:
     name: "swtpm@{{ item.name }}.service"
     state: started
@@ -44,7 +44,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Create systemd drop-in directory for TPM-enabled VMs
+- name: Create systemd drop-in directory for {{ item.name }}
   ansible.builtin.file:
     path: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d"
     state: directory
@@ -56,7 +56,7 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Deploy swtpm dependency override for TPM-enabled VMs
+- name: Deploy swtpm dependency override for {{ item.name }}
   ansible.builtin.template:
     src: qemu-vm-tpm-dependency.conf.j2
     dest: "/etc/systemd/system/qemu-vm@{{ item.name }}.service.d/tpm-dependency.conf"


### PR DESCRIPTION
## Summary

- Adds `{{ item.name }}` to all task names that are part of per-VM loops or called from a per-VM `include_tasks` loop
- Affects: `service.yml`, `shutdown.yml`, `destroy.yml`, `firmware.yml`, `cloud_init.yml`, `tpm.yml`, `novnc.yml`, `monitor.yml`, `restart.yml`
- Before: generic output like `TASK [maglo.qemu.vms : Write per-VM config]`
- After: `TASK [maglo.qemu.vms : Write config for myvm]`

## Test plan

- [ ] Run a playbook with 2+ VMs and confirm each task line in the output identifies the VM by name
- [ ] Confirm CI passes

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)