### PR TITLE
fix(vms): use double-quoted strings in default cloud-init meta-data

### DIFF
--- a/changelogs/fragments/129-fix-cloud-init-meta-data-newlines.yaml
+++ b/changelogs/fragments/129-fix-cloud-init-meta-data-newlines.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "vms - fix default cloud-init meta-data producing literal ``\\n`` instead of
+    newlines, which prevented cloud-init from setting the VM hostname (closes #129)."

--- a/roles/vms/tasks/cloud_init.yml
+++ b/roles/vms/tasks/cloud_init.yml
@@ -40,7 +40,7 @@
         dest: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}/meta-data"
         content: >-
           {{ item.cloud_init_meta_data if item.cloud_init_meta_data is defined else
-             'instance-id: ' ~ item.name ~ '\nlocal-hostname: ' ~ item.name ~ '\n' }}
+             "instance-id: " ~ item.name ~ "\nlocal-hostname: " ~ item.name ~ "\n" }}
         owner: "{{ vms_service_user }}"
         group: "{{ vms_service_group }}"
         mode: "0600"


### PR DESCRIPTION
## Summary

- In `roles/vms/tasks/cloud_init.yml`, the default `meta-data` content used single-quoted Jinja2 strings with `\n`, which are emitted as literal backslash-n characters
- Cloud-init cannot parse the resulting YAML blob and falls back to defaults, leaving the VM hostname as `localhost`
- Fix: switch to double-quoted Jinja2 strings so `\n` is interpreted as a real newline

**Before:**
```yaml
'instance-id: ' ~ item.name ~ '\nlocal-hostname: ' ~ item.name ~ '\n'
```

**After:**
```yaml
"instance-id: " ~ item.name ~ "\nlocal-hostname: " ~ item.name ~ "\n"
```

## Test plan

- [ ] Create a VM with cloud-init enabled (no explicit `cloud_init_meta_data`)
- [ ] Boot the VM and verify `hostname` matches the VM name defined in `vms_list`
- [ ] Confirm CI passes

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)