### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ maglo.qemu Release Notes
 
 .. contents:: Topics
 
+v0.3.1
+======
+
+Minor Changes
+-------------
+
+- vms - Add C(vms_default_cpu) role variable and per-VM C(cpu_model) key to make the QEMU C(-cpu) model configurable (closes #107).
+- vms - include VM name in per-VM loop task names for clearer playbook output when managing multiple VMs (closes #128).
+
+Bugfixes
+--------
+
+- host - install edk2-ovmf package for UEFI firmware support; it was incorrectly installed by the vms role instead of the host role (closes #126).
+- vms - fix default cloud-init meta-data producing literal ``\n`` instead of newlines, which prevented cloud-init from setting the VM hostname (closes #129).
+- vms - remove host role dependency to prevent double-application when following documented playbook patterns (closes #125).
+- vms - stop VM service before verifying shutdown during destroy to prevent failure when Restart=on-failure is set in the QEMU systemd service (closes #127).
+
 v0.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -188,3 +188,29 @@ releases:
     fragments:
     - 123-cloud-init-seed-iso.yaml
     release_date: '2026-02-25'
+  0.3.1:
+    changes:
+      bugfixes:
+      - 'host - install edk2-ovmf package for UEFI firmware support; it was incorrectly
+        installed by the vms role instead of the host role (closes #126).'
+      - 'vms - fix default cloud-init meta-data producing literal ``\n`` instead of
+        newlines, which prevented cloud-init from setting the VM hostname (closes
+        #129).'
+      - 'vms - remove host role dependency to prevent double-application when following
+        documented playbook patterns (closes #125).'
+      - 'vms - stop VM service before verifying shutdown during destroy to prevent
+        failure when Restart=on-failure is set in the QEMU systemd service (closes
+        #127).'
+      minor_changes:
+      - 'vms - Add C(vms_default_cpu) role variable and per-VM C(cpu_model) key to
+        make the QEMU C(-cpu) model configurable (closes #107).'
+      - 'vms - include VM name in per-VM loop task names for clearer playbook output
+        when managing multiple VMs (closes #128).'
+    fragments:
+    - 125-remove-vms-host-dependency.yaml
+    - 126-move-edk2-ovmf-to-host.yaml
+    - 127-fix-destroy-restart-on-failure.yaml
+    - 128-loop-task-names.yaml
+    - 129-fix-cloud-init-meta-data-newlines.yaml
+    - configurable-cpu-model.yaml
+    release_date: '2026-02-27'

--- a/changelogs/fragments/125-remove-vms-host-dependency.yaml
+++ b/changelogs/fragments/125-remove-vms-host-dependency.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "vms - remove host role dependency to prevent double-application when following
-    documented playbook patterns (closes #125)."

--- a/changelogs/fragments/126-move-edk2-ovmf-to-host.yaml
+++ b/changelogs/fragments/126-move-edk2-ovmf-to-host.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "host - install edk2-ovmf package for UEFI firmware support; it was incorrectly
-    installed by the vms role instead of the host role (closes #126)."

--- a/changelogs/fragments/127-fix-destroy-restart-on-failure.yaml
+++ b/changelogs/fragments/127-fix-destroy-restart-on-failure.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "vms - stop VM service before verifying shutdown during destroy to prevent
-    failure when Restart=on-failure is set in the QEMU systemd service (closes #127)."

--- a/changelogs/fragments/128-loop-task-names.yaml
+++ b/changelogs/fragments/128-loop-task-names.yaml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - "vms - include VM name in per-VM loop task names for clearer playbook output
-    when managing multiple VMs (closes #128)."

--- a/changelogs/fragments/129-fix-cloud-init-meta-data-newlines.yaml
+++ b/changelogs/fragments/129-fix-cloud-init-meta-data-newlines.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - "vms - fix default cloud-init meta-data producing literal ``\\n`` instead of
-    newlines, which prevented cloud-init from setting the VM hostname (closes #129)."

--- a/changelogs/fragments/configurable-cpu-model.yaml
+++ b/changelogs/fragments/configurable-cpu-model.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - "vms - Add C(vms_default_cpu) role variable and per-VM C(cpu_model) key to make the QEMU C(-cpu) model configurable (closes #107)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: maglo
 name: qemu
-version: 0.3.0
+version: 0.3.1
 readme: README.md
 authors:
   - maglo


### PR DESCRIPTION
## Summary

Patch release fixing all issues from the 0.3.0 manual test report (#130):

- **#125** (`vms`): Remove `host` role dependency to prevent double-application
- **#126** (`host`/`vms`): Move `edk2-ovmf` installation to the `host` role
- **#127** (`vms`): Fix destroy failing when `Restart=on-failure` is set — stop service before graceful shutdown verify
- **#128** (`vms`): Include VM name in per-VM loop task names for clearer output
- **#129** (`vms`): Fix default cloud-init meta-data generating literal `\n` instead of newlines

## Test plan

- [ ] Confirm CI passes
- [ ] Merge and tag

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)