### PR TITLE
fix(vms): use template for cloud-init meta-data

### DIFF
--- a/roles/vms/tasks/cloud_init.yml
+++ b/roles/vms/tasks/cloud_init.yml
@@ -36,11 +36,9 @@
         label: "{{ item.name }}"
 
     - name: Write cloud-init meta-data for {{ item.name }}
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: cloud-init-meta-data.j2
         dest: "{{ vms_image_dir }}/.cloud-init-staging/{{ item.name }}/meta-data"
-        content: >-
-          {{ item.cloud_init_meta_data if item.cloud_init_meta_data is defined else
-             "instance-id: " ~ item.name ~ "\nlocal-hostname: " ~ item.name ~ "\n" }}
         owner: "{{ vms_service_user }}"
         group: "{{ vms_service_group }}"
         mode: "0600"

--- a/roles/vms/templates/cloud-init-meta-data.j2
+++ b/roles/vms/templates/cloud-init-meta-data.j2
@@ -1,0 +1,4 @@
+{% if item.cloud_init_meta_data is defined %}{{ item.cloud_init_meta_data }}{% else %}
+instance-id: {{ item.name }}
+local-hostname: {{ item.name }}
+{% endif %}


### PR DESCRIPTION
## Summary

- Replaces the `ansible.builtin.copy` + inline `content:` approach with `ansible.builtin.template` and a dedicated `cloud-init-meta-data.j2` template file
- The template uses actual newlines, so there is no reliance on Jinja2 escape-sequence behaviour (`\n` in single- vs double-quoted strings) which varies and is hard to reason about
- Closes #129

## Test plan

- [ ] Deploy a VM without `cloud_init_meta_data` set and confirm `hostname` inside the VM matches the VM name
- [ ] Deploy a VM with `cloud_init_meta_data` explicitly set and confirm that content is used verbatim
- [ ] CI passes (ansible-lint, molecule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)